### PR TITLE
Implemented basic Cat follow behavior

### DIFF
--- a/2D3D_UnityProject/Assets/Scenes/Hub World.unity
+++ b/2D3D_UnityProject/Assets/Scenes/Hub World.unity
@@ -211,6 +211,114 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &729396969
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 729396974}
+  - component: {fileID: 729396973}
+  - component: {fileID: 729396972}
+  - component: {fileID: 729396971}
+  - component: {fileID: 729396970}
+  m_Layer: 0
+  m_Name: Cat
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &729396970
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 729396969}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 920a552906df94fe2bdbbdd93e1d50f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveSpeed: 5
+  followTarget: {fileID: 2062491856}
+  stoppingDistance: 2
+--- !u!65 &729396971
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 729396969}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &729396972
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 729396969}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &729396973
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 729396969}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &729396974
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 729396969}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.033, y: 0, z: 2.22}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1213724838
 GameObject:
   m_ObjectHideFlags: 0
@@ -386,6 +494,98 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2062491856
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2062491857}
+  - component: {fileID: 2062491860}
+  - component: {fileID: 2062491859}
+  - component: {fileID: 2062491858}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2062491857
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2062491856}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.33, y: 0, z: -3.2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2062491858
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2062491856}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &2062491859
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2062491856}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &2062491860
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2062491856}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &5555330885705580783
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/2D3D_UnityProject/Assets/Scripts/Cat.meta
+++ b/2D3D_UnityProject/Assets/Scripts/Cat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 95a756a0a460e4453a290b27134dfcd3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/2D3D_UnityProject/Assets/Scripts/Cat/FollowMoveController.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Cat/FollowMoveController.cs
@@ -4,42 +4,42 @@ using UnityEngine;
 
 public class FollowMoveController : MoveController
 {
+    [Header("Follow Settings")]
     /// <summary>
     /// Target to follow
     /// </summary>
     [SerializeField]
-    protected Transform followTarget;
-
-    protected Vector3 lastPosition;
+    protected GameObject followTarget;
 
     /// <summary>
-    /// Distance to lag behind target path
+    /// Radius of satisfaction around target - stop moving when we get this far away
     /// </summary>
     [SerializeField]
-    [Range(0, 5)]
-    protected float lagDistance;
+    protected float stoppingDistance;
 
     public override void MoveTowards(Vector3 position)
     {
         throw new System.NotImplementedException();
     }
 
-    public override void MoveTowards(Transform transform)
+    public override void MoveTowards(Transform targetTransform)
     {
-        if(followTargetCoroutine == null) {
-            followTargetCoroutine = StartCoroutine(FollowTarget(lastPosition));
+        // Get vector towards target
+        Vector3 toTarget = targetTransform.position - transform.position;
+        float distance = toTarget.magnitude;
+
+        // Move towards target if outside stopping radius
+        if (distance >= stoppingDistance) {
+            float step = moveSpeed * Time.fixedDeltaTime;
+            Vector3 movement = toTarget.normalized * step;
+
+            transform.position += movement;
         }
     }
 
-    Coroutine followTargetCoroutine;
-    IEnumerator FollowTarget(Vector3 position)
+    // TODO: consider moving this call to an abstract behavior component (although that's most likely overkill)
+    void Update()
     {
-        // check how far follow target has moved from last tracked position
-        // move same distance towards that follow position
-        // if distance between target and last tracked pos >= lagDistance
-        // update lastPosition and repeat
-
-
-        yield return null;
+        MoveTowards(followTarget.transform);
     }
 }

--- a/2D3D_UnityProject/Assets/Scripts/Cat/FollowMoveController.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Cat/FollowMoveController.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FollowMoveController : MoveController
+{
+    /// <summary>
+    /// Target to follow
+    /// </summary>
+    [SerializeField]
+    protected Transform followTarget;
+
+    protected Vector3 lastPosition;
+
+    /// <summary>
+    /// Distance to lag behind target path
+    /// </summary>
+    [SerializeField]
+    [Range(0, 5)]
+    protected float lagDistance;
+
+    public override void MoveTowards(Vector3 position)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public override void MoveTowards(Transform transform)
+    {
+        if(followTargetCoroutine == null) {
+            followTargetCoroutine = StartCoroutine(FollowTarget(lastPosition));
+        }
+    }
+
+    Coroutine followTargetCoroutine;
+    IEnumerator FollowTarget(Vector3 position)
+    {
+        // check how far follow target has moved from last tracked position
+        // move same distance towards that follow position
+        // if distance between target and last tracked pos >= lagDistance
+        // update lastPosition and repeat
+
+
+        yield return null;
+    }
+}

--- a/2D3D_UnityProject/Assets/Scripts/Cat/FollowMoveController.cs.meta
+++ b/2D3D_UnityProject/Assets/Scripts/Cat/FollowMoveController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 920a552906df94fe2bdbbdd93e1d50f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/2D3D_UnityProject/Assets/Scripts/Cat/MoveController.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Cat/MoveController.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class MoveController : MonoBehaviour
+{
+    public abstract void MoveTowards(Vector3 position);
+
+    public abstract void MoveTowards(Transform transform);
+}

--- a/2D3D_UnityProject/Assets/Scripts/Cat/MoveController.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Cat/MoveController.cs
@@ -4,6 +4,12 @@ using UnityEngine;
 
 public abstract class MoveController : MonoBehaviour
 {
+    /// <summary>
+    /// Movement speed
+    /// </summary>
+    [SerializeField]
+    protected float moveSpeed;
+
     public abstract void MoveTowards(Vector3 position);
 
     public abstract void MoveTowards(Transform transform);

--- a/2D3D_UnityProject/Assets/Scripts/Cat/MoveController.cs.meta
+++ b/2D3D_UnityProject/Assets/Scripts/Cat/MoveController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 392d5bf74086045e5958dba39dd0d654
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
FollowMoveController inherits from MoveController, overrides abstract move methods
- moves object towards target, stops when within radius
- not locked to any specific axis
- no rotation yet (waiting to see how cat sprites are implemented before doing that)

I added Player and Cat objects to the scene to test this out with (no movement on the player yet, i was just dragging him around the scene)

Notes for the future:

I'll likely have to refactor the MoveController to use an abstract MoveBehavior kinda deal, so we can change movement behavior on at runtime:
- Player object has a MoveController with a PlayerControlledMoveBehavior slotted in
- Cat object has a MoveController with a FollowMoveBehavior slotted in
** user switches to control cat **
- Cat object is assigned a PlayerControlledMoveBehavior
- Player object is assigned a FollowMoveBehavior (or an IdleMoveBehavior, if we want him to stay put)

this is likely overkill for a prototype stage, but if we wanted to swap perspectives that's how I'd do it