### PR TITLE
FIX: mouse-controlled orthographic camera bug

### DIFF
--- a/2D3D_UnityProject/Assets/Scripts/Player/Actor.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Player/Actor.cs
@@ -197,6 +197,9 @@ public class Actor : MonoBehaviour
     {
         gameObject.SetActive(active);
         interactionController.enabled = active;
-        ghostCamera.enabled = active;
+
+        // Re-enable ghost camera (for 3D perspective only)
+        if(perspective.cameraView.Equals(CameraController.CameraViews.THIRD_PERSON)) 
+            ghostCamera.enabled = active;
     }
 }


### PR DESCRIPTION
### Bug:
- re-enabling actor with 2D perspective resulted in mouse-controlled orthographic camera

### Fix:
Actor.Enable():
- Only activating the ghostCamera when actor has a 3D perspective