### PR TITLE
restored main menu black fade; fixed black screen bug

### DIFF
--- a/2D3D_UnityProject/Assets/Scripts/Utility/UI/MainMenu.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Utility/UI/MainMenu.cs
@@ -31,6 +31,6 @@ public class MainMenu : MonoBehaviour
         quitButton.onClick.AddListener(() => Application.Quit());
         // TODO: implement Settings button functionality
 
-        //fadeEffect.FadeIn();
+        fadeEffect.FadeIn();
     }
 }

--- a/2D3D_UnityProject/Assets/Scripts/Utility/UI/PauseMenu.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Utility/UI/PauseMenu.cs
@@ -55,7 +55,14 @@ public class PauseMenu : Singleton<PauseMenu>
     {
         // Set up button events
         resumeButton.onClick.AddListener(() => SetPaused(false));
-        quitButton.onClick.AddListener(() => SceneLoader.LoadScene(SCENE_ID.MAIN_MENU));
+        quitButton.onClick.AddListener(() =>
+        {
+            // Restore timescale to 1
+            Time.timeScale = 1;
+
+            // Load MainMenu scene
+            SceneLoader.LoadScene(SCENE_ID.MAIN_MENU);
+        });
 
         // Muffle/unmuffle music on pause/unpause
         onSetGamePaused += (paused =>


### PR DESCRIPTION
Bug:
- Game time was paused when quitting to main menu
- So when the main menu scene was reloaded, frozen time prevented the fade coroutine from iterating

Fix:
- Unpause game time before quitting to main menu