### PR TITLE
fixed bug: showing/hiding cursor didn't work properly in build

### DIFF
--- a/2D3D_UnityProject/Assets/Scripts/Utility/GameManager.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Utility/GameManager.cs
@@ -11,5 +11,6 @@ public class GameManager : MonoBehaviour
     public static void SetCursorActive(bool active)
     {
         Cursor.lockState = active ? CursorLockMode.None : CursorLockMode.Locked;
+        Cursor.visible = active;
     }
 }


### PR DESCRIPTION
### Bug:
- Cursor would be visible but locked to center of screen in build
- Sometimes it would get hidden permanently, even in menus

### Fix:
- Apparently Cursor.LockState works differently between editor and build (see below) (????)
- Now setting values for both Cursor.LockState and Cursor.visible

![image](https://user-images.githubusercontent.com/23004127/74200081-f4a94b00-4c33-11ea-9620-9126842662c8.png)

### Testing
Tested on windows, but if possible try testing a build on Mac as well