### PR TITLE
Zodiac doors opening camera

### DIFF
--- a/2D3D_UnityProject/Assets/Prefabs/Puzzles/ZodiacPuzzleFull.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/Puzzles/ZodiacPuzzleFull.prefab
@@ -36,6 +36,7 @@ MonoBehaviour:
     valueGuidInternal: 
     WwiseObjectReference: {fileID: 11400000, guid: cd75f90adc9366d4880192db18b20440,
       type: 2}
+  doorsOpenCamera: {fileID: 5474075728813891234}
   disks:
   - {fileID: 3486528819037890763}
   - {fileID: 7411421729828180524}
@@ -853,7 +854,7 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  openCloseTime: 1
+  openCloseTime: 2.5
 --- !u!1 &5263059487769909669
 GameObject:
   m_ObjectHideFlags: 0
@@ -1308,6 +1309,7 @@ Transform:
   - {fileID: 3947382476018021188}
   - {fileID: 5263059487769909668}
   - {fileID: 5263059487704158335}
+  - {fileID: 8464642851420959289}
   m_Father: {fileID: 5263059489021417088}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 270, y: 0, z: 270}
@@ -1372,6 +1374,158 @@ Transform:
   m_Father: {fileID: 2428561063460941391}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6253607173084419713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8464642851420959289}
+  - component: {fileID: 8727973878773039171}
+  - component: {fileID: 5474075728813891234}
+  - component: {fileID: 6880621074918807069}
+  m_Layer: 0
+  m_Name: OpenDoorsCamera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8464642851420959289
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6253607173084419713}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 1.23, z: 0.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5263059489151442161}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
+--- !u!20 &8727973878773039171
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6253607173084419713}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &5474075728813891234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6253607173084419713}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b2fe876df5f4eb4f8f439d1c96e34be, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6880621074918807069
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6253607173084419713}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 948f4100a11a5c24981795d21301da5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  volumeTrigger: {fileID: 8464642851420959289}
+  volumeLayer:
+    serializedVersion: 2
+    m_Bits: 256
+  stopNaNPropagation: 1
+  finalBlitToCameraTarget: 0
+  antialiasingMode: 0
+  temporalAntialiasing:
+    jitterSpread: 0.75
+    sharpness: 0.25
+    stationaryBlending: 0.95
+    motionBlending: 0.85
+  subpixelMorphologicalAntialiasing:
+    quality: 2
+  fastApproximateAntialiasing:
+    fastMode: 0
+    keepAlpha: 0
+  fog:
+    enabled: 1
+    excludeSkybox: 1
+  debugLayer:
+    lightMeter:
+      width: 512
+      height: 256
+      showCurves: 1
+    histogram:
+      width: 512
+      height: 256
+      channel: 3
+    waveform:
+      exposure: 0.12
+      height: 256
+    vectorscope:
+      size: 256
+      exposure: 0.12
+    overlaySettings:
+      linearDepth: 0
+      motionColorIntensity: 4
+      motionGridSize: 64
+      colorBlindnessType: 0
+      colorBlindnessStrength: 1
+  m_Resources: {fileID: 11400000, guid: d82512f9c8e5d4a4d938b575d47f88d4, type: 2}
+  m_ShowToolkit: 0
+  m_ShowCustomSorter: 0
+  breakBeforeColorGrading: 0
+  m_BeforeTransparentBundles: []
+  m_BeforeStackBundles:
+  - assemblyQualifiedName: IL3DN_Fog_PP, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+  - assemblyQualifiedName: PostProcessOutline, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+  m_AfterStackBundles: []
 --- !u!1 &6519992227752686012
 GameObject:
   m_ObjectHideFlags: 0
@@ -1690,21 +1844,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 700e2061b3648344181ad0617b19c0e6, type: 3}
---- !u!1 &44106540859326807 stripped
+--- !u!1 &7381689219396276912 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: -927199367670048503, guid: 700e2061b3648344181ad0617b19c0e6,
-    type: 3}
-  m_PrefabInstance: {fileID: 8339927346593028190}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &697538062640782500 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8796507058049041658, guid: 700e2061b3648344181ad0617b19c0e6,
-    type: 3}
-  m_PrefabInstance: {fileID: 8339927346593028190}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &6854487860874659829 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: -6008549739621572693, guid: 700e2061b3648344181ad0617b19c0e6,
+  m_CorrespondingSourceObject: {fileID: 1570727677198617326, guid: 700e2061b3648344181ad0617b19c0e6,
     type: 3}
   m_PrefabInstance: {fileID: 8339927346593028190}
   m_PrefabAsset: {fileID: 0}
@@ -1714,15 +1856,27 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8339927346593028190}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &7381689219396276912 stripped
+--- !u!1 &6854487860874659829 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1570727677198617326, guid: 700e2061b3648344181ad0617b19c0e6,
+  m_CorrespondingSourceObject: {fileID: -6008549739621572693, guid: 700e2061b3648344181ad0617b19c0e6,
     type: 3}
   m_PrefabInstance: {fileID: 8339927346593028190}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &3599636041546486815 stripped
+--- !u!4 &697538062640782500 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4776391023551843393, guid: 700e2061b3648344181ad0617b19c0e6,
+  m_CorrespondingSourceObject: {fileID: 8796507058049041658, guid: 700e2061b3648344181ad0617b19c0e6,
+    type: 3}
+  m_PrefabInstance: {fileID: 8339927346593028190}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &44106540859326807 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -927199367670048503, guid: 700e2061b3648344181ad0617b19c0e6,
+    type: 3}
+  m_PrefabInstance: {fileID: 8339927346593028190}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &3947382476018021188 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -4216859302048453862, guid: 700e2061b3648344181ad0617b19c0e6,
     type: 3}
   m_PrefabInstance: {fileID: 8339927346593028190}
   m_PrefabAsset: {fileID: 0}
@@ -1732,9 +1886,9 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 8339927346593028190}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &3947382476018021188 stripped
+--- !u!4 &3599636041546486815 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -4216859302048453862, guid: 700e2061b3648344181ad0617b19c0e6,
+  m_CorrespondingSourceObject: {fileID: 4776391023551843393, guid: 700e2061b3648344181ad0617b19c0e6,
     type: 3}
   m_PrefabInstance: {fileID: 8339927346593028190}
   m_PrefabAsset: {fileID: 0}

--- a/2D3D_UnityProject/Assets/Prefabs/environment/House.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/environment/House.prefab
@@ -11441,7 +11441,7 @@ GameObject:
   - component: {fileID: 2999863943029060693}
   - component: {fileID: 2362639183286923765}
   m_Layer: 0
-  m_Name: circle_door
+  m_Name: LeftDoor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -11455,7 +11455,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3279894838234460002}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 24.861563, y: 1.4012672, z: -3.1865237}
+  m_LocalPosition: {x: 24.861563, y: 1.4012672, z: -1.53}
   m_LocalScale: {x: 3, y: 3, z: 3}
   m_Children: []
   m_Father: {fileID: 5358870190501456689}
@@ -35153,7 +35153,7 @@ GameObject:
   - component: {fileID: 7450157939319079759}
   - component: {fileID: 374152905375094252}
   m_Layer: 0
-  m_Name: circle_door1
+  m_Name: RightDoor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -35167,7 +35167,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8822726327669968902}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 24.861551, y: 1.4012672, z: 2.119858}
+  m_LocalPosition: {x: 24.861551, y: 1.4012672, z: 1.237}
   m_LocalScale: {x: 3, y: 3, z: 3}
   m_Children: []
   m_Father: {fileID: 5358870190501456689}

--- a/2D3D_UnityProject/Assets/Scenes/Ukiyo-e Environment.unity
+++ b/2D3D_UnityProject/Assets/Scenes/Ukiyo-e Environment.unity
@@ -11669,12 +11669,12 @@ PrefabInstance:
         type: 3}
       propertyPath: leftDoor
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1095527506}
     - target: {fileID: 5263059487704158320, guid: 14aa88c43fd3d874989f821b940a1074,
         type: 3}
       propertyPath: rightDoor
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1891361976}
     - target: {fileID: 5263059489021417088, guid: 14aa88c43fd3d874989f821b940a1074,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -12602,6 +12602,12 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3360329922263324231, guid: a5b864fe7ab693b4ebbfb3e1502aac7e,
     type: 3}
   m_PrefabInstance: {fileID: 1093196262}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1095527506 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6612073571527416435, guid: fd7faa83115f80249a233f9abedd7e27,
+    type: 3}
+  m_PrefabInstance: {fileID: 1553414912}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1107182314
 PrefabInstance:
@@ -30732,6 +30738,12 @@ Transform:
   m_Father: {fileID: 172057613}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1891361976 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2711874826665060198, guid: fd7faa83115f80249a233f9abedd7e27,
+    type: 3}
+  m_PrefabInstance: {fileID: 1553414912}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1900459391
 GameObject:
   m_ObjectHideFlags: 0

--- a/2D3D_UnityProject/Assets/Scripts/Player/PlayerInteractionController.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Player/PlayerInteractionController.cs
@@ -102,7 +102,7 @@ public class PlayerInteractionController : MonoBehaviour
 
                 GameManager.SetCursorActive(true);
             }
-            else if (inZodiacZone)
+            else if (inZodiacZone && !zodiacPuzzle.solved)
             {
                 // Enable and shift focus to Zodiac puzzle
                 zodiacPuzzle.enabled = true;

--- a/2D3D_UnityProject/Assets/Scripts/Puzzles/Zodiac/ZodiacPuzzle.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Puzzles/Zodiac/ZodiacPuzzle.cs
@@ -72,7 +72,10 @@ public class ZodiacPuzzle : MonoBehaviour
     [SerializeField]
     private DoubleSlidingDoors zodiacDoor;
 
-    private bool solved = false;
+    /// <summary>
+    /// Indicates whether player has solved the puzzle
+    /// </summary>
+    public bool solved = false;
 
     public GameObject zodiacCanvas;
 
@@ -193,8 +196,7 @@ public class ZodiacPuzzle : MonoBehaviour
         }
         else
         {
-            if (!solved)
-                PuzzleSolved();
+            PuzzleSolved();
         }
     }
 
@@ -203,6 +205,10 @@ public class ZodiacPuzzle : MonoBehaviour
     /// </summary>
     private void PuzzleSolved()
     {
+        // Make sure we haven't already solved it before (shouldn't be possible)
+        if (solved)
+            return;
+
         // TODO: maybe a smooth camera pan from puzzle view to doors
         // Show camera view of doors opening
         CameraController cameraController = CameraController.Instance;

--- a/2D3D_UnityProject/Assets/Scripts/Puzzles/Zodiac/ZodiacPuzzle.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Puzzles/Zodiac/ZodiacPuzzle.cs
@@ -203,6 +203,7 @@ public class ZodiacPuzzle : MonoBehaviour
     /// </summary>
     private void PuzzleSolved()
     {
+        // TODO: maybe a smooth camera pan from puzzle view to doors
         // Show camera view of doors opening
         CameraController cameraController = CameraController.Instance;
         cameraController.SetMainCamera(doorsOpenCamera);
@@ -217,6 +218,9 @@ public class ZodiacPuzzle : MonoBehaviour
         zodiacDoor.Open();
         doorMove.Post(gameObject); //Wwise
         solved = true;
+        
+        // Disable puzzle
+        enabled = false;
     }
 
     

--- a/2D3D_UnityProject/Assets/Scripts/Puzzles/Zodiac/ZodiacPuzzle.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Puzzles/Zodiac/ZodiacPuzzle.cs
@@ -7,16 +7,6 @@ using UnityEngine;
 
 public class ZodiacPuzzle : MonoBehaviour
 {
-    //n8-bit 2/16/2020
-    /// <summary>
-    /// This code activates the dev cheat to solve the Zodiac puzzle upon pressing 0
-    /// </summary>
-    public void cheat_it_up()
-    {
-        //Well, this function makes it pretty simple
-        PuzzleSolved();
-    }
-    //End n8-bit 2/16/2020
 
     [Header("Wwise")]
     /// <summary>
@@ -25,6 +15,15 @@ public class ZodiacPuzzle : MonoBehaviour
     /// <param name="paused">Set Wwise variables for sounds here</param>
     public AK.Wwise.Event stoneMove;
     public AK.Wwise.Event doorMove;
+
+    [Header("Camera Settings")] 
+
+    /// <summary>
+    /// Camera that shows doors opening when puzzle is solved
+    /// </summary>
+    [SerializeField]
+    private CameraEntity doorsOpenCamera;
+
 
     /// <summary>
     /// The number of rounds that must be solved in order to complete the puzzle
@@ -38,6 +37,7 @@ public class ZodiacPuzzle : MonoBehaviour
         CLOCKWISE = 1,
         COUNTER_CLOCKWISE = -1,
     }
+    [Header("Puzzle Settings")]
 
     /// <summary>
     /// Ordered list of rotating disks, from outermost to innermost
@@ -97,13 +97,11 @@ public class ZodiacPuzzle : MonoBehaviour
 
     void Update()
     {
-        //n8-bit 2/16/2020
         //If we're in the editor and press 0, run the dev cheat
         if (Input.GetKeyDown(KeyCode.Alpha0) && Application.isEditor)
         {
-            cheat_it_up();
+            PuzzleSolved();
         }
-        //End n8-bit 2/16/2020
 
         if (Input.GetKeyDown(KeyCode.W)) 
         {
@@ -117,16 +115,7 @@ public class ZodiacPuzzle : MonoBehaviour
         //TODO: Move this to a generalized interaction script
         if (Input.GetKeyDown(KeyCode.E))
         {
-            // Restore control to player actor
-            Actor actor = PlayerController.Instance.GetPlayer();
-            actor.Enable();
-            CameraController.Instance.SetMainCamera(actor.actorCamera);
-
-            // Restore actor swapping
-            PlayerController.Instance.canSwap = true;
-
-            // Disable the puzzle
-            this.enabled = false;
+            ExitPuzzle();
         }
 
         RotateDisk();
@@ -209,14 +198,43 @@ public class ZodiacPuzzle : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Opens doors and restores control to player
+    /// </summary>
     private void PuzzleSolved()
     {
-        // TODO: Maybe disable to center coming out now that we have lights
-        // currentDisk.PieceInOut(ZodiacPuzzlePiece.ZodiacPuzzlePiecePosition.In);
-        // center.PieceInOut(ZodiacPuzzlePiece.ZodiacPuzzlePiecePosition.Out);
+        // Show camera view of doors opening
+        CameraController cameraController = CameraController.Instance;
+        cameraController.SetMainCamera(doorsOpenCamera);
+
+        // Switch back to player actor when doors finished opening
+        zodiacDoor.onFinished += () =>
+        {
+            ExitPuzzle();
+        };
+
+        // Open doors
         zodiacDoor.Open();
         doorMove.Post(gameObject); //Wwise
         solved = true;
+    }
+
+    
+    /// <summary>
+    /// Exits puzzle and restores control to player
+    /// </summary>
+    private void ExitPuzzle()
+    {
+        // Restore control to player actor
+        Actor actor = PlayerController.Instance.GetPlayer();
+        actor.Enable();
+        CameraController.Instance.SetMainCamera(actor.actorCamera);
+
+        // Restore actor swapping
+        PlayerController.Instance.canSwap = true;
+
+        // Disable the puzzle
+        this.enabled = false;
     }
 
     void OnEnable()

--- a/2D3D_UnityProject/Assets/Scripts/Puzzles/Zodiac/ZodiacTriggerZone.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Puzzles/Zodiac/ZodiacTriggerZone.cs
@@ -19,6 +19,10 @@ public class ZodiacTriggerZone : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
+        // Ignore interaction if we've already solved the zodiac puzzle
+        if (puzzleScript.solved)
+            return;
+
         PlayerInteractionController controller = other.GetComponent<PlayerInteractionController>();
         if (controller != null)
             controller.SetInZodiacZone(true, puzzleScript, camZodiac);

--- a/2D3D_UnityProject/Assets/Scripts/Utility/DoubleSlidingDoors.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Utility/DoubleSlidingDoors.cs
@@ -13,7 +13,14 @@ public class DoubleSlidingDoors : MonoBehaviour
     [SerializeField]
     private float openCloseTime;
 
-    private float openCloseOffset = 50f;
+    private float openCloseOffset = 3f;
+
+    public delegate void OnFinishedOpenClose();
+
+    /// <summary>
+    /// Event fired after door finished opening/closing
+    /// </summary>
+    public OnFinishedOpenClose onFinished;
 
     public void Open()
     {
@@ -30,6 +37,7 @@ public class DoubleSlidingDoors : MonoBehaviour
         // Create start and end positions for both doors
         Vector3 leftDoorStartPos = leftDoor.localPosition;
         Vector3 leftDoorEndPos = new Vector3(leftDoorStartPos.x, leftDoorStartPos.y, leftDoorStartPos.z + offset);
+
         Vector3 rightDoorStartPos = rightDoor.localPosition;
         Vector3 rightDoorEndPos = new Vector3(rightDoorStartPos.x, rightDoorStartPos.y, rightDoorStartPos.z - offset);
 
@@ -52,5 +60,8 @@ public class DoubleSlidingDoors : MonoBehaviour
         // Unlikely last loop of curve will land on exactly openCloseTime so set final position
         leftDoor.localPosition = leftDoorEndPos;
         rightDoor.localPosition = rightDoorEndPos;
+
+        // Fire finished opening/closing event
+        onFinished?.Invoke();
     }
 }


### PR DESCRIPTION
# Zodiac Doors Camera
![zodiac doors opening camera](https://user-images.githubusercontent.com/23004127/74705957-93f5b180-51e3-11ea-84ef-6c73e1ae87ac.gif)

- After solving the puzzle, the camera cuts to a view of the doors opening
- Once the doors finish opening, it switches back to the player
- After the puzzle has been solved, the player can't interact with it anymore

-----

### Code Changes
- Added a delegate to DoubleSlidingDoors.cs
- PlayerInteractionController checks if puzzle is solved before interacting
- ZodiacTriggerZone checks if puzzle solved before showing interact canvas

----

### Things to test
- Camera works as expected
- Doors open properly
- No way to interact with the puzzle after solving it