### PR TITLE
suppressing TopCam animation warning logs

### DIFF
--- a/2D3D_UnityProject/Assets/Characters/Cat/Cat_Anim_CRTL.controller
+++ b/2D3D_UnityProject/Assets/Characters/Cat/Cat_Anim_CRTL.controller
@@ -320,19 +320,25 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: MoveY
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Speed
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: TopCam
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer


### PR DESCRIPTION
added TopCam parameter to Cat's anim controller to suppress the annoying warnings flooding the console

(this can be a blind merge, no functionality added/changed)