### PR TITLE
Koi pond overhead camera

### DIFF
--- a/2D3D_UnityProject/Assets/Prefabs/PerspectiveController.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/PerspectiveController.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 4208683251683716152}
   - component: {fileID: 1782685005}
   m_Layer: 0
-  m_Name: GameManager
+  m_Name: PerspectiveController
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -53,7 +53,7 @@ MonoBehaviour:
   - cameraView: 1
     movement: {fileID: 11400000, guid: cf8fffaca5b5f4fa09eb844ae0652b28, type: 2}
     orthographic: 1
-    orthographicCameraRotation: {x: 90, y: 0, z: 0}
+    orthographicCameraRotation: {x: 90, y: 0, z: 90}
     orthographicCameraOffset: {x: 0, y: 20, z: 2}
   - cameraView: 2
     movement: {fileID: 11400000, guid: 61ffe63a94824490bb2910930cba2845, type: 2}

--- a/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
@@ -356,6 +356,8 @@ Transform:
   - {fileID: 82394518}
   - {fileID: 541874476}
   - {fileID: 4569386871960128341}
+  - {fileID: 8839546053043120210}
+  - {fileID: 2579654556143643178}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -387,6 +389,152 @@ MonoBehaviour:
   - {fileID: 4336892304538896218}
   - {fileID: 1695647121906843341}
   - {fileID: 1695647122670680291}
+--- !u!1 &6012771079940451124
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2579654556143643178}
+  - component: {fileID: 7547067297079253392}
+  - component: {fileID: 4600529328941341031}
+  m_Layer: 0
+  m_Name: OverheadCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2579654556143643178
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6012771079940451124}
+  m_LocalRotation: {x: 0.5, y: -0.5, z: 0.5, w: 0.5}
+  m_LocalPosition: {x: -16, y: 45, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4336892303693815517}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 90, y: -90, z: 0}
+--- !u!20 &7547067297079253392
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6012771079940451124}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &4600529328941341031
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6012771079940451124}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b2fe876df5f4eb4f8f439d1c96e34be, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7723202500339263361
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8839546053043120210}
+  - component: {fileID: 4250984228286755347}
+  - component: {fileID: 1289812128352152282}
+  m_Layer: 0
+  m_Name: CameraTrigger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8839546053043120210
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7723202500339263361}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -18.4, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4336892303693815517}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4250984228286755347
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7723202500339263361}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 55.45, y: 3, z: 43.75}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1289812128352152282
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7723202500339263361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 914ab19ebe097bb438d74240359afba8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  camera: {fileID: 4600529328941341031}
+  cameraView: 1
 --- !u!1001 &858463989691151033
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -606,12 +754,6 @@ PrefabInstance:
       objectReference: {fileID: 9000000, guid: dc7790b56327cd34c8593ad4d60453ed, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c70da449cea496f43a91f05df312e485, type: 3}
---- !u!4 &4336892304538896219 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
-    type: 3}
-  m_PrefabInstance: {fileID: 1695647121371994062}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4336892304538896218 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3145652739638300820, guid: c70da449cea496f43a91f05df312e485,
@@ -624,6 +766,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e59f4640a1247504aa3229990875e32d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &4336892304538896219 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
+    type: 3}
+  m_PrefabInstance: {fileID: 1695647121371994062}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4336892305077939801
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -768,12 +916,6 @@ PrefabInstance:
       objectReference: {fileID: 9000000, guid: 14ede709e2969a24fb6e4c07e785d29b, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c70da449cea496f43a91f05df312e485, type: 3}
---- !u!4 &1695647121906843340 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
-    type: 3}
-  m_PrefabInstance: {fileID: 4336892305077939801}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1695647121906843341 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3145652739638300820, guid: c70da449cea496f43a91f05df312e485,
@@ -786,6 +928,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e59f4640a1247504aa3229990875e32d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &1695647121906843340 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
+    type: 3}
+  m_PrefabInstance: {fileID: 4336892305077939801}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4336892305455900791
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -930,12 +1078,6 @@ PrefabInstance:
       objectReference: {fileID: 9000000, guid: bf4529705bb0c8546ba3b2c3dea38ac9, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c70da449cea496f43a91f05df312e485, type: 3}
---- !u!4 &1695647122670680290 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
-    type: 3}
-  m_PrefabInstance: {fileID: 4336892305455900791}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1695647122670680291 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3145652739638300820, guid: c70da449cea496f43a91f05df312e485,
@@ -948,3 +1090,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e59f4640a1247504aa3229990875e32d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &1695647122670680290 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
+    type: 3}
+  m_PrefabInstance: {fileID: 4336892305455900791}
+  m_PrefabAsset: {fileID: 0}

--- a/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
@@ -535,6 +535,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   camera: {fileID: 4600529328941341031}
   cameraView: 1
+  restrictPerspectiveSwitching: 1
 --- !u!1001 &858463989691151033
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
@@ -28,7 +28,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 82394517}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -9.22, y: -0.49, z: -1.6}
+  m_LocalPosition: {x: -18.9, y: -0.49, z: -16.4}
   m_LocalScale: {x: 2, y: 0.2, z: 2}
   m_Children: []
   m_Father: {fileID: 4336892303693815517}
@@ -135,7 +135,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 541874475}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -8.94, y: -0.56, z: 4.36}
+  m_LocalPosition: {x: -14.2, y: -0.56, z: 15.6}
   m_LocalScale: {x: 2, y: 0.2, z: 2}
   m_Children: []
   m_Father: {fileID: 4336892303693815517}
@@ -242,7 +242,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1778993040}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -12.58, y: -0.607, z: 1.14}
+  m_LocalPosition: {x: -21.3, y: -0.607, z: 16.5}
   m_LocalScale: {x: 2, y: 0.2, z: 2}
   m_Children: []
   m_Father: {fileID: 4336892303693815517}
@@ -376,15 +376,18 @@ MonoBehaviour:
   Fish1:
     idInternal: 0
     valueGuidInternal: 
-    WwiseObjectReference: {fileID: 0}
+    WwiseObjectReference: {fileID: 11400000, guid: 54c8793a9c2c0e340a9012f12a095a81,
+      type: 2}
   FishWin:
     idInternal: 0
     valueGuidInternal: 
-    WwiseObjectReference: {fileID: 0}
+    WwiseObjectReference: {fileID: 11400000, guid: 335d7c95d300b394a8bc2bdacc820a37,
+      type: 2}
   FishLose:
     idInternal: 0
     valueGuidInternal: 
-    WwiseObjectReference: {fileID: 0}
+    WwiseObjectReference: {fileID: 11400000, guid: 82c1b4517237f57449824be036a5a9c5,
+      type: 2}
   koiFishFeedingOrder:
   - {fileID: 4336892304538896218}
   - {fileID: 1695647121906843341}
@@ -848,7 +851,7 @@ PrefabInstance:
     - target: {fileID: 3145652739638300820, guid: c70da449cea496f43a91f05df312e485,
         type: 3}
       propertyPath: feedDuration
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3145652739638300820, guid: c70da449cea496f43a91f05df312e485,
         type: 3}
@@ -1010,7 +1013,7 @@ PrefabInstance:
     - target: {fileID: 3145652739638300820, guid: c70da449cea496f43a91f05df312e485,
         type: 3}
       propertyPath: feedDuration
-      value: 2.5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3145652739638300820, guid: c70da449cea496f43a91f05df312e485,
         type: 3}

--- a/2D3D_UnityProject/Assets/Scripts/Camera/CameraTrigger.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Camera/CameraTrigger.cs
@@ -19,7 +19,14 @@ public class CameraTrigger : MonoBehaviour
     /// </summary>
     [SerializeField]
     private OldCameraController.CameraViews cameraView;
+
+    /// <summary>
+    /// Used to track actors within trigger bounds
+    /// </summary>
+    private List<Actor> actorsInTrigger = new List<Actor>();
+
     private PerspectiveController perspectiveController => PerspectiveController.Instance;
+    private CameraController cameraController => CameraController.Instance;
 
     void Awake()
     {
@@ -32,35 +39,64 @@ public class CameraTrigger : MonoBehaviour
             Debug.LogError($"Error: CameraTrigger {name} | collider not marked as Trigger");
     }
 
-    private void OnTriggerEnter(Collider other)
+    private void LateUpdate()
     {
-        // Ignore everything but the player actor
-        Actor player = PlayerController.Instance.GetPlayer();
-        if (other.gameObject != player.gameObject)
+        if (actorsInTrigger.Count == 0)
             return;
 
-        // Set player movement/animation to match this camera's pespective
-        perspectiveController.SetPerspective(player, perspectiveController.GetPerspectiveByType(cameraView));
-        //player.SetTopView(cameraView == OldCameraController.CameraViews.TOP);
+        // If player is in trigger zone, make sure we're using the referenced camera (handles actor swapping)
+        Actor player = PlayerController.Instance.GetPlayer();
+        if (actorsInTrigger.Contains(player) && cameraController.GetMainCamera() == player.actorCamera) {
+            SwitchToCamera(player);
+        }
+    }
 
-        // Switch to specified camera
-        Debug.LogWarning($"Switching to trigger camera: {camera.name}");
-        CameraController.Instance.SetMainCamera(camera);
+    private void OnTriggerEnter(Collider other)
+    {
+        // Ignore interactions with non-actor objects
+        if (!other.TryGetComponent(out Actor actor))
+            return;
+
+        // Track actor in bounds
+        actorsInTrigger.Add(actor);
+
+        // If this is the player, switch to the referenced camera
+        if (actor == PlayerController.Instance.GetPlayer())
+        {
+            SwitchToCamera(actor);
+        }
     }
 
     private void OnTriggerExit(Collider other)
     {
-        // Ignore everything but the player actor
-        Actor player = PlayerController.Instance.GetPlayer();
-        if (other.gameObject != player.gameObject)
+        // Ignore interactions with non-actor objects
+        if (!other.TryGetComponent(out Actor actor))
             return;
 
-        // Switch to actor camera
-        Debug.LogWarning($"Switching to actor camera ({player.name})");
-        CameraController.Instance.SetMainCamera(player.actorCamera);
+        // Stop tracking this actor
+        actorsInTrigger.Remove(actor);
 
-        // Set actor to 3rd person perspective
-        Perspective thirdPersonPerspective = perspectiveController.GetPerspectiveByType(OldCameraController.CameraViews.THIRD_PERSON);
-        perspectiveController.SetPerspective(player, thirdPersonPerspective);
+        // If this is the player, switch back to actor camera
+        if (actor == PlayerController.Instance.GetPlayer())
+        {
+            cameraController.SetMainCamera(actor.actorCamera);
+
+            // Set actor to 3rd person perspective
+            Perspective thirdPersonPerspective = perspectiveController.GetPerspectiveByType(OldCameraController.CameraViews.THIRD_PERSON);
+            perspectiveController.SetPerspective(actor, thirdPersonPerspective);
+        }
+    }
+
+    /// <summary>
+    /// Switches to referenced camera, updating actor movement/animation accordingly
+    /// </summary>
+    /// <param name="actor"></param>
+    private void SwitchToCamera(Actor actor)
+    {
+        // Set player movement/animation to match this camera's pespective
+        perspectiveController.SetPerspective(actor, perspectiveController.GetPerspectiveByType(cameraView));
+
+        // Switch to specified camera
+        cameraController.SetMainCamera(camera);
     }
 }

--- a/2D3D_UnityProject/Assets/Scripts/Camera/CameraTrigger.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Camera/CameraTrigger.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Activates a camera when player actor enters the trigger zone
+/// </summary>
+[RequireComponent(typeof(Collider))]
+public class CameraTrigger : MonoBehaviour
+{
+    /// <summary>
+    /// Camera to use when player enters trigger 
+    /// </summary>
+    [SerializeField]
+    private CameraEntity camera;
+
+    /// <summary>
+    /// Controls which perspective sprites the actor should use
+    /// </summary>
+    [SerializeField]
+    private OldCameraController.CameraViews cameraView;
+
+    void Awake()
+    {
+        if(!camera)
+            Debug.LogError($"Error: CameraTrigger {name} missing reference to CameraEntity");
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        // Ignore everything but the player actor
+        Actor player = PlayerController.Instance.GetPlayer();
+        if (other.gameObject != player.gameObject)
+            return;
+
+        // Switch to specified camera
+        Debug.LogWarning($"Switching to trigger camera: {camera.name}");
+        CameraController.Instance.SetMainCamera(camera);
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        // Ignore everything but the player actor
+        Actor player = PlayerController.Instance.GetPlayer();
+        if (other.gameObject != player.gameObject)
+            return;
+
+        // Restore actor camera
+        Debug.LogWarning($"Switching to actor camera ({player.name})");
+        CameraController.Instance.SetMainCamera(player.actorCamera);
+    }
+}

--- a/2D3D_UnityProject/Assets/Scripts/Camera/CameraTrigger.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Camera/CameraTrigger.cs
@@ -21,6 +21,12 @@ public class CameraTrigger : MonoBehaviour
     private OldCameraController.CameraViews cameraView;
 
     /// <summary>
+    /// If true, player won't be able to switch perspectives inside the trigger
+    /// </summary>
+    [SerializeField]
+    private bool restrictPerspectiveSwitching = true;
+
+    /// <summary>
     /// Used to track actors within trigger bounds
     /// </summary>
     private List<Actor> actorsInTrigger = new List<Actor>();
@@ -63,6 +69,9 @@ public class CameraTrigger : MonoBehaviour
         // Track actor in bounds
         actorsInTrigger.Add(actor);
 
+        // Prevent actor from changing perspectives if specified
+        actor.canSwitchPerspectives = !restrictPerspectiveSwitching;
+
         // If player entered trigger, switch to the referenced camera
         if (actor == playerController.GetPlayer())
             SwitchToReferencedCamera(actor);
@@ -74,8 +83,9 @@ public class CameraTrigger : MonoBehaviour
         if (!other.TryGetComponent(out Actor actor))
             return;
 
-        // Stop tracking this actor
+        // Stop tracking this actor, and restore perspective switching
         actorsInTrigger.Remove(actor);
+        actor.canSwitchPerspectives = true;
 
         // If player left trigger, switch back to actor camera
         if (actor == playerController.GetPlayer())

--- a/2D3D_UnityProject/Assets/Scripts/Camera/CameraTrigger.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Camera/CameraTrigger.cs
@@ -19,11 +19,17 @@ public class CameraTrigger : MonoBehaviour
     /// </summary>
     [SerializeField]
     private OldCameraController.CameraViews cameraView;
+    private PerspectiveController perspectiveController => PerspectiveController.Instance;
 
     void Awake()
     {
+        // Make sure we're pointing to a camera
         if(!camera)
-            Debug.LogError($"Error: CameraTrigger {name} missing reference to CameraEntity");
+            Debug.LogError($"Error: CameraTrigger {name} | missing reference to CameraEntity");
+
+        // Make sure our collider is marked as a trigger
+        if(TryGetComponent(out Collider trigger) && !trigger.isTrigger)
+            Debug.LogError($"Error: CameraTrigger {name} | collider not marked as Trigger");
     }
 
     private void OnTriggerEnter(Collider other)
@@ -32,6 +38,10 @@ public class CameraTrigger : MonoBehaviour
         Actor player = PlayerController.Instance.GetPlayer();
         if (other.gameObject != player.gameObject)
             return;
+
+        // Set player movement/animation to match this camera's pespective
+        perspectiveController.SetPerspective(player, perspectiveController.GetPerspectiveByType(cameraView));
+        //player.SetTopView(cameraView == OldCameraController.CameraViews.TOP);
 
         // Switch to specified camera
         Debug.LogWarning($"Switching to trigger camera: {camera.name}");
@@ -45,8 +55,12 @@ public class CameraTrigger : MonoBehaviour
         if (other.gameObject != player.gameObject)
             return;
 
-        // Restore actor camera
+        // Switch to actor camera
         Debug.LogWarning($"Switching to actor camera ({player.name})");
         CameraController.Instance.SetMainCamera(player.actorCamera);
+
+        // Set actor to 3rd person perspective
+        Perspective thirdPersonPerspective = perspectiveController.GetPerspectiveByType(OldCameraController.CameraViews.THIRD_PERSON);
+        perspectiveController.SetPerspective(player, thirdPersonPerspective);
     }
 }

--- a/2D3D_UnityProject/Assets/Scripts/Camera/CameraTrigger.cs.meta
+++ b/2D3D_UnityProject/Assets/Scripts/Camera/CameraTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 914ab19ebe097bb438d74240359afba8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/2D3D_UnityProject/Assets/Scripts/Player/Actor.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Player/Actor.cs
@@ -88,12 +88,19 @@ public class Actor : MonoBehaviour
         this.movement = movement;
     }
 
+    [Header("Perspective Settings")]
+
     /// <summary>
     /// Current perspective used for this actor (remains unchanged when not player-controlled)
     /// </summary>
     /// <value></value>
     public Perspective perspective;
-    
+
+    /// <summary>
+    /// Determines whether this actor currently allows player to switch perspectives
+    /// </summary>
+    public bool canSwitchPerspectives = true;
+
     void Awake()
     {
         // Get components in Awake() before other scripts request them in Start()

--- a/2D3D_UnityProject/Assets/Scripts/Player/Movement/TopDownMovement.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Player/Movement/TopDownMovement.cs
@@ -17,23 +17,23 @@ public class TopDownMovement : Movement
         // Up/Down = change in Z
         if (Input.GetKey(KeyCode.W))
         {
-            movement += Vector3.forward;
+            movement += Vector3.left;
         }
 
         if (Input.GetKey(KeyCode.S))
         {
-            movement += Vector3.back;
+            movement += Vector3.right;
         }
 
         // Left/Right = change in X
         if (Input.GetKey(KeyCode.A))
         {
-            movement += Vector3.left;
+            movement += Vector3.back;
         }
 
         if (Input.GetKey(KeyCode.D))
         {
-            movement += Vector3.right;
+            movement += Vector3.forward;
         }
 
         return movement.normalized;

--- a/2D3D_UnityProject/Assets/Scripts/Player/Perspective/PerspectiveController.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Player/Perspective/PerspectiveController.cs
@@ -112,11 +112,6 @@ public class PerspectiveController : Singleton<PerspectiveController>
                     continue;
                 }
 
-                // Tell animator if we're using the top-down perspective (so it displays appropriate sprites)
-                if(perspective.cameraView == OldCameraController.CameraViews.TOP)
-                    PlayerController.Instance.GetPlayer().SetTopView(true);
-                else
-                    PlayerController.Instance.GetPlayer().SetTopView(false);
                 
                 SetPerspective(player, perspective);
 
@@ -132,6 +127,9 @@ public class PerspectiveController : Singleton<PerspectiveController>
 
         // Update actor with associated movement scheme
         player.SetMovement(perspective.movement);
+
+        // Tell actor if we're using the top-down perspective (so animator displays appropriate sprites)
+        player.SetTopView(perspective.cameraView == OldCameraController.CameraViews.TOP);
 
         // Apply camera perspective to player actor
         player.actorCamera.SetPerspective(perspective);

--- a/2D3D_UnityProject/Assets/Scripts/Player/Perspective/PerspectiveController.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Player/Perspective/PerspectiveController.cs
@@ -95,6 +95,9 @@ public class PerspectiveController : Singleton<PerspectiveController>
     /// <param name="player">Player actor to update perspective for</param>
     public void UpdatePerspective(Actor player)
     {
+        if (!player.canSwitchPerspectives)
+            return;
+
         // Check each button in KeyCode -> camera perspective mapping
         foreach(KeyCode key in buttonPerspectiveMapping.Keys) 
         {
@@ -112,9 +115,8 @@ public class PerspectiveController : Singleton<PerspectiveController>
                     continue;
                 }
 
-                
+                // Set perspective and break from loop
                 SetPerspective(player, perspective);
-
                 return;
             }
         }


### PR DESCRIPTION
Added a fixed overhead camera above the Koi Pond. When the player is near the Koi Pond, it switches to this camera.

Moved the koi fish feeding pods around the pond.

(sorry i'd take a gif but laptop is slow)

### Testing
- Approach the Koi Pond
    - The camera should switch to an overhead view
- Move away from the koi pond
    - The camera should switch back to your actor
- Feed koi fish and try to solve the puzzle
    - (no visible win state, besides a log in the console)

### Bugs
- The player's walk sprites are rotated the wrong way (result of changing our overhead camera angle to face towards the end of the level)

