### PR TITLE
Koi Pond camera: fixed outline camera bug, added post-processing

### DIFF
--- a/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
@@ -403,6 +403,8 @@ GameObject:
   - component: {fileID: 2579654556143643178}
   - component: {fileID: 7547067297079253392}
   - component: {fileID: 4600529328941341031}
+  - component: {fileID: 4238066584960400005}
+  - component: {fileID: 8356598736762202981}
   m_Layer: 0
   m_Name: OverheadCamera
   m_TagString: Untagged
@@ -479,6 +481,89 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b2fe876df5f4eb4f8f439d1c96e34be, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &4238066584960400005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6012771079940451124}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 948f4100a11a5c24981795d21301da5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  volumeTrigger: {fileID: 0}
+  volumeLayer:
+    serializedVersion: 2
+    m_Bits: 256
+  stopNaNPropagation: 0
+  finalBlitToCameraTarget: 1
+  antialiasingMode: 2
+  temporalAntialiasing:
+    jitterSpread: 0.75
+    sharpness: 0.25
+    stationaryBlending: 0.95
+    motionBlending: 0.85
+  subpixelMorphologicalAntialiasing:
+    quality: 2
+  fastApproximateAntialiasing:
+    fastMode: 0
+    keepAlpha: 0
+  fog:
+    enabled: 0
+    excludeSkybox: 1
+  debugLayer:
+    lightMeter:
+      width: 512
+      height: 256
+      showCurves: 1
+    histogram:
+      width: 512
+      height: 256
+      channel: 3
+    waveform:
+      exposure: 0.12
+      height: 256
+    vectorscope:
+      size: 256
+      exposure: 0.12
+    overlaySettings:
+      linearDepth: 0
+      motionColorIntensity: 4
+      motionGridSize: 64
+      colorBlindnessType: 0
+      colorBlindnessStrength: 1
+  m_Resources: {fileID: 11400000, guid: d82512f9c8e5d4a4d938b575d47f88d4, type: 2}
+  m_ShowToolkit: 0
+  m_ShowCustomSorter: 1
+  breakBeforeColorGrading: 0
+  m_BeforeTransparentBundles:
+  - assemblyQualifiedName: PostProcessOutline, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+  m_BeforeStackBundles:
+  - assemblyQualifiedName: IL3DN_Fog_PP, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+  m_AfterStackBundles: []
+--- !u!114 &8356598736762202981
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6012771079940451124}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0e998adac808c7a4196bb47824729d5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  replacementShader: {fileID: 4800000, guid: f2a8679a4d5bd3b49b70059efa246a26, type: 3}
+  renderTextureFormat: 0
+  filterMode: 0
+  renderTextureDepth: 24
+  cameraClearFlags: 2
+  background: {r: 1, g: 1, b: 1, a: 1}
+  targetTexture: _CameraNormalsTexture
 --- !u!1 &7723202500339263361
 GameObject:
   m_ObjectHideFlags: 0
@@ -758,6 +843,12 @@ PrefabInstance:
       objectReference: {fileID: 9000000, guid: dc7790b56327cd34c8593ad4d60453ed, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c70da449cea496f43a91f05df312e485, type: 3}
+--- !u!4 &4336892304538896219 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
+    type: 3}
+  m_PrefabInstance: {fileID: 1695647121371994062}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4336892304538896218 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3145652739638300820, guid: c70da449cea496f43a91f05df312e485,
@@ -770,12 +861,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e59f4640a1247504aa3229990875e32d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &4336892304538896219 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
-    type: 3}
-  m_PrefabInstance: {fileID: 1695647121371994062}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4336892305077939801
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -920,6 +1005,12 @@ PrefabInstance:
       objectReference: {fileID: 9000000, guid: 14ede709e2969a24fb6e4c07e785d29b, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c70da449cea496f43a91f05df312e485, type: 3}
+--- !u!4 &1695647121906843340 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
+    type: 3}
+  m_PrefabInstance: {fileID: 4336892305077939801}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1695647121906843341 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3145652739638300820, guid: c70da449cea496f43a91f05df312e485,
@@ -932,12 +1023,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e59f4640a1247504aa3229990875e32d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1695647121906843340 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
-    type: 3}
-  m_PrefabInstance: {fileID: 4336892305077939801}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4336892305455900791
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/2D3D_UnityProject/Assets/Prefabs/Puzzles/ZodiacPuzzleFull.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/Puzzles/ZodiacPuzzleFull.prefab
@@ -1425,7 +1425,7 @@ Camera:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6253607173084419713}
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 2
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}

--- a/2D3D_UnityProject/Assets/Scripts/Camera/CameraController.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Camera/CameraController.cs
@@ -34,6 +34,18 @@ public class CameraController : Singleton<CameraController>
         SetMainCamera(main);
 
         // TODO: disable all other Cameras in scene?
+        foreach(CameraEntity cameraEntity in GameObject.FindObjectsOfType<CameraEntity>())
+        {
+            if(cameraEntity != main)
+            {
+                Camera camera = cameraEntity.GetComponent<Camera>();
+                if(camera.isActiveAndEnabled)
+                {
+                    Debug.LogWarning($"CameraController | found an enabled camera \"{camera.name}\"not in use, disabling it now");
+                    camera.enabled = false;
+                }
+            }
+        }
     }
 
     void Update()


### PR DESCRIPTION
## Before:
![image](https://user-images.githubusercontent.com/23004127/79282134-63985f80-7e82-11ea-94e4-65b2f9ed9f78.png)

## After:
![image](https://user-images.githubusercontent.com/23004127/79393803-141a6800-7f44-11ea-8fa0-0e080e9ea726.png)

Changes:
- Fixed the outline bug 
- Added post-processing and outline script to koi pond camrea

### Main Fix
The problem was that the Zodiac camera was enabled in scene, and lower in the hierarchy than the Koi pond camera, so it was drawing the outline on top.

CameraController.Awake() now turns off any enabled cameras (with a CameraEntity component) besides the main one, so this shouldn't happen again.