### PR TITLE
Disable liars triggers

### DIFF
--- a/2D3D_UnityProject/Assets/Puzzles/Liars/Liar Statue Layout.prefab
+++ b/2D3D_UnityProject/Assets/Puzzles/Liars/Liar Statue Layout.prefab
@@ -1015,12 +1015,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7d5634f29acea4448b40e0680b79079a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  dialogueRunner: {fileID: 0}
+  triggerZones:
+  - {fileID: 8011365831497939017}
+  - {fileID: 8011365831870289557}
+  - {fileID: 8011365832499762058}
+  - {fileID: 8011365831755792321}
+  - {fileID: 8011365833003832196}
+  - {fileID: 8011365831434810144}
   puzzleSolved:
     idInternal: 0
     valueGuidInternal: 
-    WwiseObjectReference: {fileID: 11400000, guid: 8e4fff8ee6203de46844db3723dea656,
+    WwiseObjectReference: {fileID: 11400000, guid: 335d7c95d300b394a8bc2bdacc820a37,
       type: 2}
-  dialogueRunner: {fileID: 0}
   cutscene5: {fileID: 0}
 --- !u!1 &8011365831434810158
 GameObject:

--- a/2D3D_UnityProject/Assets/Scripts/Yarnspinner Commands/LiarCommands.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Yarnspinner Commands/LiarCommands.cs
@@ -4,8 +4,10 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using Yarn.Unity;
 
-public class LiarCommands : MonoBehaviour
+public class LiarCommands : DialogueCommands
 {
+    [SerializeField]
+    private Collider[] triggerZones;
 
     [Header("Wwise")]
     /// <summary>
@@ -14,11 +16,6 @@ public class LiarCommands : MonoBehaviour
     /// <param name="paused">Set Wwise variables for sounds here</param>
     public AK.Wwise.Event puzzleSolved;
     /// <summary>
- 
-
-    // Drag and drop your Dialogue Runner into this variable.
-    [SerializeField]
-    private DialogueRunner dialogueRunner;
 
     [SerializeField]
     private GameObject cutscene5;
@@ -28,10 +25,16 @@ public class LiarCommands : MonoBehaviour
         dialogueRunner.AddCommandHandler("liar_win", LiarWin);
     }
 
-    private void LiarWin(string[] parameters)
+    private void LiarWin(string[] parameters, System.Action onComplete)
     {
         //stuff for when players solve liars puzzle
         puzzleSolved.Post(gameObject); //Wwise
         cutscene5.SetActive(true);
+        foreach(Collider trigger in triggerZones)
+        {
+            trigger.enabled = false;
+        }
+        
+        onComplete();
     }
 }

--- a/2D3D_UnityProject/Assets/Scripts/Yarnspinner Commands/LiarCommands.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Yarnspinner Commands/LiarCommands.cs
@@ -30,11 +30,17 @@ public class LiarCommands : DialogueCommands
         //stuff for when players solve liars puzzle
         puzzleSolved.Post(gameObject); //Wwise
         cutscene5.SetActive(true);
+
+        PlayerInteractionController controller = PlayerController.Instance.GetPlayer().GetComponent<PlayerInteractionController>();
+
+        if (controller != null)
+            controller.SetInDialogueZone(false, null, null);
+        
         foreach(Collider trigger in triggerZones)
         {
             trigger.enabled = false;
         }
-        
+
         onComplete();
     }
 }


### PR DESCRIPTION
When you solve liars puzzle, turns off trigger colliders to prevent interaction

Testing instructions
1) check able to interact with liars before solving
2) solve liars
3) exit dialogue
4) check interaction prompt isn't showing
5) walk around liars room, make sure interaction prompt doesn't show
6) press 'E', make sure you don't re-teleport into talking with a liar