### PR TITLE
Hooked up Teledoor Puzzle scene

### DIFF
--- a/2D3D_UnityProject/Assets/Scripts/Puzzles/TeleportDoors/LoadTeledoorScene.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Puzzles/TeleportDoors/LoadTeledoorScene.cs
@@ -25,6 +25,6 @@ public class LoadTeledoorScene : MonoBehaviour
             return;
         }
         //otherwise continue
-        SceneLoader.LoadScene(SCENE_ID.TELEDOOR_INTRO);
+        SceneLoader.LoadScene(SCENE_ID.TELEDOOR);
     }
 }

--- a/2D3D_UnityProject/Assets/Scripts/Utility/SceneLoader.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Utility/SceneLoader.cs
@@ -27,7 +27,7 @@ public class SceneLoader
     // WARNING: IF THESE ARE INCORRECT SCENE LOADING WILL BREAK
     private const string MainMenuScene = "MainMenu";
     private const string UkiyoeScene = "Ukiyo-e Environment";
-    private const string TeledoorScene = "Puzzles/TeledoorPuzzle";
+    private const string TeledoorScene = "Puzzles/NewPortalPuzzle";
     private const string IntroScene = "Intro";
     private const string OpeningScene = "Opening Scene";
     private const string FinalScene = "Final Scene";
@@ -63,7 +63,8 @@ public class SceneLoader
         }
 
         // Load scene
+        // TODO: consider using LoadSceneAsync() to eliminate performance hiccups while loading
         Debug.LogFormat("Successfully found {0} scene path; loading scene {1}.unity", sceneId, scenePath);
-        SceneManager.LoadScene(scenePath);
+        SceneManager.LoadScene("Scenes/" + scenePath);
     }
 }

--- a/2D3D_UnityProject/ProjectSettings/EditorBuildSettings.asset
+++ b/2D3D_UnityProject/ProjectSettings/EditorBuildSettings.asset
@@ -29,4 +29,7 @@ EditorBuildSettings:
   - enabled: 0
     path: Assets/Scenes/TeledoorPuzzle Intro.unity
     guid: 1373c342b011e5b45ada0bf8de619af3
+  - enabled: 1
+    path: Assets/Scenes/Puzzles/NewPortalPuzzle.unity
+    guid: 9d6fc617e588e31488ddaeeae1c6a33d
   m_configObjects: {}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23004127/80157415-20ca3c00-8594-11ea-8fd5-8714680ea31b.png)

- Added new Teledoor Puzzle scene (`Puzzles/NewPortalPuzzle.unity`) to BuildSettings.asset
- Scene loads in game when entering above portal

----

### Testing

- Open Ukiyo-e Scene
- Go to portal house pictured above
- Attempt to walk through portal
    - (there's a strange invisible collider in the way, so you'll have to clip through the bushes on the left and touch it from the back)
- You should appear in the NewPortalPuzzle scene (the textures are pink, don't worry about that)