### PR TITLE
Koi Fish Puzzle no longer interactable after solving

### DIFF
--- a/2D3D_UnityProject/Assets/Scripts/Player/PlayerInteractionController.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Player/PlayerInteractionController.cs
@@ -51,6 +51,10 @@ public class PlayerInteractionController : MonoBehaviour
 
     private ZodiacPuzzle zodiacPuzzle;
 
+    private KoiFishPuzzle koiPuzzle => KoiFishPuzzle.Instance;
+
+    private PatternPuzzle patternPuzzle;
+
     /// <summary>
     /// Shown when actor is near an interactable
     /// </summary>
@@ -70,8 +74,6 @@ public class PlayerInteractionController : MonoBehaviour
     /// True if player is in the pattern puzzle zone
     /// </summary>
     private bool inPatternZone;
-
-    private PatternPuzzle patternPuzzle;
 
     /// <summary>
     /// Holds CameraEntity of nearby interactable (if it has one)
@@ -116,7 +118,7 @@ public class PlayerInteractionController : MonoBehaviour
                 CameraController.Instance.SetMainCamera(interactionCamera);
 
             }
-            else if (nearbyFish)
+            else if (nearbyFish && !koiPuzzle.solved)
             {
                 // Feed nearby fish
                 KoiFishPuzzle.Instance.FeedFish(nearbyFish);

--- a/2D3D_UnityProject/Assets/Scripts/Puzzles/KoiFish_YingYang/KoiFishFeedingPod.cs
+++ b/2D3D_UnityProject/Assets/Scripts/Puzzles/KoiFish_YingYang/KoiFishFeedingPod.cs
@@ -23,6 +23,10 @@ public class KoiFishFeedingPod : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
+        // Don't prompt player to interact if puzzle already solved
+        if (KoiFishPuzzle.Instance.solved)
+            return;
+
         if (other.TryGetComponent(out PlayerInteractionController playerInteractionController))
             playerInteractionController.SetInKoiFishZone(true, koiFish);
 


### PR DESCRIPTION
After solving the puzzle, the player can no longer feed the fish.

Something to consider: it might be nice to switch from the overhead pond camera back to the regular actor camera after solving the puzzle (maybe after a 5 second delay or so)

### Files changed
- KoiFishFeedingPod.cs
- PlayerInteractionController.cs

### Testing
1. Solve the Koi Fish puzzle
2. Ensure the fish can no longer be fed