### PR TITLE
fixed perspective indicator icon sprites

### DIFF
--- a/2D3D_UnityProject/Assets/Prefabs/UI/Overlay.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/UI/Overlay.prefab
@@ -790,7 +790,7 @@ PrefabInstance:
         type: 3}
       propertyPath: sprite
       value: 
-      objectReference: {fileID: 21300000, guid: a5c44b1f4a87c5349abb90b1e8c308e4,
+      objectReference: {fileID: 21300000, guid: 8c561c7f1d33a834cb06bce8b9243590,
         type: 3}
     - target: {fileID: 6060154649510301388, guid: abe8d208b6a29c643b370418c1177370,
         type: 3}


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/23004127/81227689-d5178980-8fba-11ea-9f83-fa0eb4e34de9.png)

## After
![image](https://user-images.githubusercontent.com/23004127/81227556-9a155600-8fba-11ea-9d59-17c75c7f1ffb.png)


Side view/back views icons were showing same sprite, as you can see above.

### Files changed
- `UI/Overlay.prefab`