### PR TITLE
Fix Koi Pond colliders

### DIFF
--- a/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
@@ -2113,6 +2113,12 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c70da449cea496f43a91f05df312e485, type: 3}
+--- !u!4 &1695647121906843340 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
+    type: 3}
+  m_PrefabInstance: {fileID: 4336892305077939801}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1695647121906843341 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3145652739638300820, guid: c70da449cea496f43a91f05df312e485,
@@ -2125,12 +2131,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e59f4640a1247504aa3229990875e32d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1695647121906843340 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
-    type: 3}
-  m_PrefabInstance: {fileID: 4336892305077939801}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4336892305455900791
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2281,6 +2281,12 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c70da449cea496f43a91f05df312e485, type: 3}
+--- !u!4 &1695647122670680290 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
+    type: 3}
+  m_PrefabInstance: {fileID: 4336892305455900791}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1695647122670680291 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3145652739638300820, guid: c70da449cea496f43a91f05df312e485,
@@ -2293,12 +2299,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e59f4640a1247504aa3229990875e32d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1695647122670680290 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3145652739638300821, guid: c70da449cea496f43a91f05df312e485,
-    type: 3}
-  m_PrefabInstance: {fileID: 4336892305455900791}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4569770966739957894
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/KoiFishPuzzle.prefab
@@ -1178,51 +1178,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3783121911853479133, guid: 4422a40c3b197ce4eaee07faf7548512,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 26.850004
-      objectReference: {fileID: 0}
-    - target: {fileID: 3783121911829983559, guid: 4422a40c3b197ce4eaee07faf7548512,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 119.33024
-      objectReference: {fileID: 0}
-    - target: {fileID: 3783121911564385273, guid: 4422a40c3b197ce4eaee07faf7548512,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 26.850006
-      objectReference: {fileID: 0}
-    - target: {fileID: 5399911883873937033, guid: 4422a40c3b197ce4eaee07faf7548512,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -6.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 7099304445411872406, guid: 4422a40c3b197ce4eaee07faf7548512,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 7099304445411872406, guid: 4422a40c3b197ce4eaee07faf7548512,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 7099304445411872406, guid: 4422a40c3b197ce4eaee07faf7548512,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -5.11
-      objectReference: {fileID: 0}
-    - target: {fileID: 7099304445411872406, guid: 4422a40c3b197ce4eaee07faf7548512,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 8.31
-      objectReference: {fileID: 0}
-    - target: {fileID: 7099304445411872406, guid: 4422a40c3b197ce4eaee07faf7548512,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -90
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4422a40c3b197ce4eaee07faf7548512, type: 3}
 --- !u!4 &4569386871960128341 stripped

--- a/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/Koi_Fish_Pond.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/Puzzles/Koi_Puzzle/Koi_Fish_Pond.prefab
@@ -61,7 +61,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3783121911564385274}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -18.349998, y: 0, z: 0}
+  m_LocalPosition: {x: 26.850006, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8213138122132780879}
@@ -133,7 +133,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3783121911829983576}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 74.13023, y: 3.0721033, z: -4.59684}
+  m_LocalPosition: {x: 119.33024, y: 3.0721033, z: -4.59684}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1883088585838699216}
@@ -277,7 +277,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3783121911853479134}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -18.35, y: 0, z: 0}
+  m_LocalPosition: {x: 26.850004, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 3783121910916142371}
@@ -308,7 +308,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3783121911928928749}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -3.6680954, z: 1.5859146}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -1536,6 +1536,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1.5411011
       objectReference: {fileID: 0}
+    - target: {fileID: 449489735629676091, guid: 2acbdb370bce0504abe2193c4ba47e0b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 07cc3125984276f4a9ef1d55531ff35f, type: 2}
     - target: {fileID: 8829897421360989703, guid: 2acbdb370bce0504abe2193c4ba47e0b,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1556,11 +1561,6 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 2.163
       objectReference: {fileID: 0}
-    - target: {fileID: 449489735629676091, guid: 2acbdb370bce0504abe2193c4ba47e0b,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 07cc3125984276f4a9ef1d55531ff35f, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2acbdb370bce0504abe2193c4ba47e0b, type: 3}
 --- !u!4 &8213138120786873370 stripped
@@ -3393,6 +3393,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1.5411012
       objectReference: {fileID: 0}
+    - target: {fileID: 449489735629676091, guid: 2acbdb370bce0504abe2193c4ba47e0b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e598bac885ddee4468acc422d5899f2b, type: 2}
     - target: {fileID: 8829897421360989703, guid: 2acbdb370bce0504abe2193c4ba47e0b,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -3423,11 +3428,6 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 2.3911
       objectReference: {fileID: 0}
-    - target: {fileID: 449489735629676091, guid: 2acbdb370bce0504abe2193c4ba47e0b,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: e598bac885ddee4468acc422d5899f2b, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2acbdb370bce0504abe2193c4ba47e0b, type: 3}
 --- !u!4 &8213138121182907979 stripped
@@ -8116,6 +8116,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1.5411011
       objectReference: {fileID: 0}
+    - target: {fileID: 449489735629676091, guid: 2acbdb370bce0504abe2193c4ba47e0b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e598bac885ddee4468acc422d5899f2b, type: 2}
     - target: {fileID: 8829897421360989703, guid: 2acbdb370bce0504abe2193c4ba47e0b,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8136,11 +8141,6 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 2.309
       objectReference: {fileID: 0}
-    - target: {fileID: 449489735629676091, guid: 2acbdb370bce0504abe2193c4ba47e0b,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: e598bac885ddee4468acc422d5899f2b, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2acbdb370bce0504abe2193c4ba47e0b, type: 3}
 --- !u!4 &8213138122122538991 stripped
@@ -8801,6 +8801,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1.5411012
       objectReference: {fileID: 0}
+    - target: {fileID: 449489735629676091, guid: 2acbdb370bce0504abe2193c4ba47e0b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e598bac885ddee4468acc422d5899f2b, type: 2}
     - target: {fileID: 8829897421360989703, guid: 2acbdb370bce0504abe2193c4ba47e0b,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8836,11 +8841,6 @@ PrefabInstance:
       propertyPath: m_LocalPosition.y
       value: 0.928
       objectReference: {fileID: 0}
-    - target: {fileID: 449489735629676091, guid: 2acbdb370bce0504abe2193c4ba47e0b,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: e598bac885ddee4468acc422d5899f2b, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2acbdb370bce0504abe2193c4ba47e0b, type: 3}
 --- !u!4 &8213138122356868990 stripped
@@ -10613,7 +10613,7 @@ PrefabInstance:
     - target: {fileID: 3874780736277433514, guid: ef115a1d21825f0409bbc88dc93d273b,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -33.024055
+      value: -5.11
       objectReference: {fileID: 0}
     - target: {fileID: 3874780736277433514, guid: ef115a1d21825f0409bbc88dc93d273b,
         type: 3}
@@ -10623,7 +10623,7 @@ PrefabInstance:
     - target: {fileID: 3874780736277433514, guid: ef115a1d21825f0409bbc88dc93d273b,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.5995598
+      value: 8.31
       objectReference: {fileID: 0}
     - target: {fileID: 3874780736277433514, guid: ef115a1d21825f0409bbc88dc93d273b,
         type: 3}
@@ -10633,7 +10633,7 @@ PrefabInstance:
     - target: {fileID: 3874780736277433514, guid: ef115a1d21825f0409bbc88dc93d273b,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 3874780736277433514, guid: ef115a1d21825f0409bbc88dc93d273b,
         type: 3}
@@ -10643,7 +10643,7 @@ PrefabInstance:
     - target: {fileID: 3874780736277433514, guid: ef115a1d21825f0409bbc88dc93d273b,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 3874780736277433514, guid: ef115a1d21825f0409bbc88dc93d273b,
         type: 3}
@@ -10658,7 +10658,7 @@ PrefabInstance:
     - target: {fileID: 3874780736277433514, guid: ef115a1d21825f0409bbc88dc93d273b,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 3874780736277433514, guid: ef115a1d21825f0409bbc88dc93d273b,
         type: 3}
@@ -11023,7 +11023,7 @@ PrefabInstance:
     - target: {fileID: 2139315878358439016, guid: d0c29f8eb56e217449e23b21cea22e17,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -51.450005
+      value: -6.25
       objectReference: {fileID: 0}
     - target: {fileID: 2139315878358439016, guid: d0c29f8eb56e217449e23b21cea22e17,
         type: 3}

--- a/2D3D_UnityProject/Assets/Prefabs/environment/Koi_Pond.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/environment/Koi_Pond.prefab
@@ -1,5 +1,50 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1071195613740107139
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 226697757065873532}
+  - component: {fileID: 5963241649819088105}
+  m_Layer: 0
+  m_Name: colliders (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &226697757065873532
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071195613740107139}
+  m_LocalRotation: {x: -0, y: -0.5875475, z: -0, w: 0.80918974}
+  m_LocalPosition: {x: -0.0238, y: 0.016555587, z: -0.0785}
+  m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
+  m_Children: []
+  m_Father: {fileID: 2139315878358439016}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &5963241649819088105
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071195613740107139}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 11
+  m_Height: 13.648407
+  m_Direction: 1
+  m_Center: {x: -0.2015881, y: 0, z: 0}
 --- !u!114 &4241830336152758511
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -56,50 +101,6 @@ MonoBehaviour:
     positionOffset: {x: 0, y: 0, z: 0}
   m_posOffsetData: {fileID: 0}
   listenerMask: 1
---- !u!1 &1307989599872447041
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1625450485318917055}
-  - component: {fileID: 2028008548150958520}
-  m_Layer: 0
-  m_Name: colliders
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1625450485318917055
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1307989599872447041}
-  m_LocalRotation: {x: -0, y: -0.5875475, z: -0, w: 0.80918974}
-  m_LocalPosition: {x: -0.0354, y: 0.016555587, z: -0.0912}
-  m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
-  m_Children: []
-  m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &2028008548150958520
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1307989599872447041}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 9.860867, y: 4.8280225, z: 12.823256}
-  m_Center: {x: -4.4475346, y: -0.25970885, z: 0.39815062}
 --- !u!1 &1441539742504560626
 GameObject:
   m_ObjectHideFlags: 0
@@ -125,11 +126,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1441539742504560626}
   m_LocalRotation: {x: -0, y: -0.8813306, z: -0, w: 0.47250018}
-  m_LocalPosition: {x: -0.0121, y: 0.016555587, z: -0.0945}
+  m_LocalPosition: {x: -0.0101, y: 0.016555587, z: -0.091}
   m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
   m_Children: []
   m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: -123.607, z: 0}
 --- !u!65 &480702322421744423
 BoxCollider:
@@ -153,7 +154,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2212943635767871815}
-  - component: {fileID: 1894603424858820947}
+  - component: {fileID: 7846269679662715128}
   m_Layer: 0
   m_Name: colliders (5)
   m_TagString: Untagged
@@ -169,14 +170,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1473638255942157095}
   m_LocalRotation: {x: -0, y: -0.5875475, z: -0, w: 0.80918974}
-  m_LocalPosition: {x: 0.043, y: 0.016555587, z: 0.1548}
+  m_LocalPosition: {x: 0.0335, y: 0.016555587, z: 0.0743}
   m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
   m_Children: []
   m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &1894603424858820947
-BoxCollider:
+--- !u!136 &7846269679662715128
+CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -185,9 +186,55 @@ BoxCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 14.037451, y: 4.8280225, z: 5.607079}
-  m_Center: {x: -10.421012, y: -0.25970885, z: -4.39147}
+  m_Radius: 7.8
+  m_Height: 13.648407
+  m_Direction: 1
+  m_Center: {x: -0.2015881, y: 0, z: 0}
+--- !u!1 &1915263855968032856
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3427834628318240954}
+  - component: {fileID: 6957638227452557067}
+  m_Layer: 0
+  m_Name: colliders (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3427834628318240954
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1915263855968032856}
+  m_LocalRotation: {x: -0, y: -0.5875475, z: -0, w: 0.80918974}
+  m_LocalPosition: {x: -0.0143, y: 0.016555587, z: 0.0879}
+  m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
+  m_Children: []
+  m_Father: {fileID: 2139315878358439016}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &6957638227452557067
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1915263855968032856}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 7.8
+  m_Height: 13.648407
+  m_Direction: 1
+  m_Center: {x: -0.2015881, y: 0, z: 0}
 --- !u!1 &3164686574063363707
 GameObject:
   m_ObjectHideFlags: 0
@@ -215,63 +262,18 @@ Transform:
   m_LocalPosition: {x: -1.137001, y: -0.35800004, z: -1.4465599}
   m_LocalScale: {x: 119.56562, y: 81.22272, z: 137.2583}
   m_Children:
-  - {fileID: 1625450485318917055}
   - {fileID: 2859927230155865726}
   - {fileID: 1653371571100956835}
   - {fileID: 7424860868265688611}
   - {fileID: 5668059410098887477}
   - {fileID: 2212943635767871815}
   - {fileID: 4002916021404111106}
-  - {fileID: 3930453431880049427}
-  - {fileID: 8375014829222577400}
   - {fileID: 4136523412501458233}
+  - {fileID: 226697757065873532}
+  - {fileID: 3427834628318240954}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 71.966, z: 0}
---- !u!1 &3646707679309446251
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8375014829222577400}
-  - component: {fileID: 2571213524994701289}
-  m_Layer: 0
-  m_Name: colliders (8)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8375014829222577400
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3646707679309446251}
-  m_LocalRotation: {x: -0, y: 0.5749438, z: -0, w: 0.818193}
-  m_LocalPosition: {x: 0.0114, y: 0.016555587, z: 0.0179}
-  m_LocalScale: {x: 0.0030268445, y: 0.011864061, z: 0.0033838274}
-  m_Children: []
-  m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 70.191, z: 0}
---- !u!65 &2571213524994701289
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3646707679309446251}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 14.037451, y: 4.8280225, z: 5.607079}
-  m_Center: {x: -10.421012, y: -0.25970885, z: -4.39147}
 --- !u!1 &4281409562773872190
 GameObject:
   m_ObjectHideFlags: 0
@@ -296,13 +298,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4281409562773872190}
-  m_LocalRotation: {x: -0, y: -0.11394435, z: -0, w: 0.9934871}
-  m_LocalPosition: {x: -0.059, y: 0.016555587, z: -0.0738}
+  m_LocalRotation: {x: 0, y: 0.18480907, z: 0, w: 0.98277444}
+  m_LocalPosition: {x: -0.0775, y: 0.016555587, z: -0.033}
   m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
   m_Children: []
   m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: -13.085001, z: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 21.3, z: 0}
 --- !u!65 &1212363963279600531
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -314,8 +316,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 9.860867, y: 4.8280225, z: 11.570937}
-  m_Center: {x: -4.380995, y: -0.25970885, z: -0.64969593}
+  m_Size: {x: 9.180189, y: 4.8280225, z: 11.570934}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5859798989810198206
 GameObject:
   m_ObjectHideFlags: 0
@@ -340,13 +342,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5859798989810198206}
-  m_LocalRotation: {x: -0, y: -0.99226964, z: -0, w: -0.12410036}
-  m_LocalPosition: {x: -0.01, y: 0.016555587, z: 0.0169}
+  m_LocalRotation: {x: -0, y: -0.9996101, z: 0, w: -0.027921487}
+  m_LocalPosition: {x: 0.0681, y: 0.016555587, z: 0.0359}
   m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
   m_Children: []
   m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: -194.258, z: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: -183.2, z: 0}
 --- !u!65 &112865078384561450
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -358,8 +360,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 5.673603, y: 4.8280225, z: 15.205167}
-  m_Center: {x: -13.945052, y: -0.25970885, z: -2.1803124}
+  m_Size: {x: 9.37, y: 4.8280225, z: 11.078685}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &6719748475657299855
 GameObject:
   m_ObjectHideFlags: 0
@@ -385,11 +387,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6719748475657299855}
   m_LocalRotation: {x: -0, y: -0.5875475, z: -0, w: 0.80918974}
-  m_LocalPosition: {x: -0.0725, y: 0.016555587, z: 0.1877}
+  m_LocalPosition: {x: 0.0109, y: 0.016555587, z: 0.0773}
   m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
   m_Children: []
   m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &8028431355851493237
 BoxCollider:
@@ -402,52 +404,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 14.145247, y: 4.8280225, z: 10.376074}
-  m_Center: {x: -10.215049, y: -0.25970885, z: -7.9318213}
---- !u!1 &8442869903870033835
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3930453431880049427}
-  - component: {fileID: 5197583079543949261}
-  m_Layer: 0
-  m_Name: colliders (6)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3930453431880049427
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8442869903870033835}
-  m_LocalRotation: {x: -0, y: -0.25563025, z: -0, w: 0.9667746}
-  m_LocalPosition: {x: 0.0413, y: 0.016555587, z: 0.0595}
-  m_LocalScale: {x: 0.0030268445, y: 0.011864061, z: 0.0033838274}
-  m_Children: []
-  m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: -29.622002, z: 0}
---- !u!65 &5197583079543949261
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8442869903870033835}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 14.037451, y: 4.8280225, z: 5.607079}
-  m_Center: {x: -10.421012, y: -0.25970885, z: -4.39147}
+  m_Size: {x: 15.3, y: 4.8280225, z: 12.94}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &8720308148651886835
 GameObject:
   m_ObjectHideFlags: 0
@@ -477,7 +435,7 @@ Transform:
   m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
   m_Children: []
   m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &1379096916445825873
 BoxCollider:
@@ -490,8 +448,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 17.846478, y: 4.8280225, z: 25.582024}
-  m_Center: {x: -8.688439, y: -0.25970885, z: -0.3874948}
+  m_Size: {x: 12.719393, y: 4.8280225, z: 25.050749}
+  m_Center: {x: -11.244792, y: -0.25970885, z: -0.5549231}
 --- !u!1001 &8943400015744058915
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -542,7 +500,7 @@ PrefabInstance:
     - target: {fileID: -4216859302048453862, guid: d3ef05419a1c2f44b8777c1f1b03f7b8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: d3ef05419a1c2f44b8777c1f1b03f7b8,
         type: 3}

--- a/2D3D_UnityProject/Assets/Prefabs/environment/Koi_Pond.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/environment/Koi_Pond.prefab
@@ -158,7 +158,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1441539742504560626}
   m_LocalRotation: {x: 0, y: 0.43680182, z: 0, w: 0.89955777}
-  m_LocalPosition: {x: -18.64, y: 0.87731475, z: 3.94}
+  m_LocalPosition: {x: -17.02, y: 0.87731475, z: 1.75}
   m_LocalScale: {x: 0.93513405, y: 1, z: 1.0725169}
   m_Children: []
   m_Father: {fileID: 1830317250909015653}
@@ -175,7 +175,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 4.8280225, z: 11.570937}
+  m_Size: {x: 6.52, y: 4.8280225, z: 11.570937}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1473638255942157095
 GameObject:
@@ -299,9 +299,54 @@ Transform:
   - {fileID: 3427834628318240954}
   - {fileID: 5668059410098887477}
   - {fileID: 8642056788288058711}
+  - {fileID: 262916707896517737}
   m_Father: {fileID: 8658485523284553378}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2914233337848864925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 262916707896517737}
+  - component: {fileID: 8071495672113951193}
+  m_Layer: 0
+  m_Name: Box (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &262916707896517737
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2914233337848864925}
+  m_LocalRotation: {x: 0, y: 0.020069981, z: 0, w: 0.9997986}
+  m_LocalPosition: {x: -0.0666, y: 0.016555589, z: 0.0726}
+  m_LocalScale: {x: 0.007388857, y: 0.012311829, z: 0.008260292}
+  m_Children: []
+  m_Father: {fileID: 8443339724056421785}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 2.3, z: 0}
+--- !u!65 &8071495672113951193
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2914233337848864925}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 3.83, y: 4.8280225, z: 4.97}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &3164686574063363707
 GameObject:
   m_ObjectHideFlags: 0
@@ -359,7 +404,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4013137427442207082}
   m_LocalRotation: {x: 0, y: -0.6198474, z: 0, w: 0.7847224}
-  m_LocalPosition: {x: 0.0971, y: 0.016555589, z: -0.0384}
+  m_LocalPosition: {x: 0.0633, y: 0.016555589, z: -0.0274}
   m_LocalScale: {x: 0.007388857, y: 0.012311829, z: 0.008260292}
   m_Children: []
   m_Father: {fileID: 8443339724056421785}
@@ -376,7 +421,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 11.6, y: 4.8280225, z: 1}
+  m_Size: {x: 10, y: 4.8280225, z: 10}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &4281409562773872190
 GameObject:
@@ -446,13 +491,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5859798989810198206}
-  m_LocalRotation: {x: -0, y: -0.9996102, z: -0, w: -0.027921498}
-  m_LocalPosition: {x: 0.1059, y: 0.016555589, z: 0.0346}
+  m_LocalRotation: {x: -0, y: -0.99791, z: 0, w: -0.064619385}
+  m_LocalPosition: {x: 0.0703, y: 0.016555589, z: 0.0366}
   m_LocalScale: {x: 0.0073888595, y: 0.012311829, z: 0.008260294}
   m_Children: []
   m_Father: {fileID: 8443339724056421785}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: -183.2, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -187.41, z: 0}
 --- !u!65 &112865078384561450
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -464,7 +509,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 4.8280225, z: 11.078685}
+  m_Size: {x: 9.48, y: 4.8280225, z: 11.078685}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &6719748475657299855
 GameObject:
@@ -490,13 +535,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6719748475657299855}
-  m_LocalRotation: {x: 0, y: 0.012216957, z: 0, w: 0.9999254}
-  m_LocalPosition: {x: -0.0805, y: 0.016555589, z: 0.0724}
+  m_LocalRotation: {x: 0, y: 0.16013956, z: 0, w: 0.9870944}
+  m_LocalPosition: {x: -0.0641, y: 0.016555589, z: 0.0664}
   m_LocalScale: {x: 0.007388857, y: 0.012311829, z: 0.008260292}
   m_Children: []
   m_Father: {fileID: 8443339724056421785}
   m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 1.4, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 18.43, z: 0}
 --- !u!65 &8028431355851493237
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -508,7 +553,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 4.8280225, z: 6.3}
+  m_Size: {x: 3.83, y: 4.8280225, z: 6.3}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &7446017454597549903
 GameObject:
@@ -568,13 +613,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8720308148651886835}
-  m_LocalRotation: {x: -0, y: -0.0000028014176, z: -0, w: 1}
-  m_LocalPosition: {x: -7.18, y: 0.87731475, z: -18.28}
+  m_LocalRotation: {x: 0, y: 0.0209424, z: 0, w: 0.9997807}
+  m_LocalPosition: {x: -8, y: 0.87731475, z: -15.53}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1830317250909015653}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 2.4, z: 0}
 --- !u!65 &1379096916445825873
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -586,7 +631,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 12.719393, y: 4.8280225, z: 1}
+  m_Size: {x: 12.719393, y: 4.8280225, z: 5.89}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &8943400015744058915
 PrefabInstance:
@@ -677,15 +722,15 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: 9b9fdaaebc85b1241bfb6f555b58ae15, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d3ef05419a1c2f44b8777c1f1b03f7b8, type: 3}
---- !u!1 &1097959084888071978 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: -927199367670048503, guid: d3ef05419a1c2f44b8777c1f1b03f7b8,
-    type: 3}
-  m_PrefabInstance: {fileID: 8943400015744058915}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4136523412501458233 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -4216859302048453862, guid: d3ef05419a1c2f44b8777c1f1b03f7b8,
+    type: 3}
+  m_PrefabInstance: {fileID: 8943400015744058915}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1097959084888071978 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -927199367670048503, guid: d3ef05419a1c2f44b8777c1f1b03f7b8,
     type: 3}
   m_PrefabInstance: {fileID: 8943400015744058915}
   m_PrefabAsset: {fileID: 0}

--- a/2D3D_UnityProject/Assets/Prefabs/environment/Koi_Pond.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/environment/Koi_Pond.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 226697757065873532}
   - component: {fileID: 5963241649819088105}
   m_Layer: 0
-  m_Name: colliders (8)
+  m_Name: Capsule
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -24,12 +24,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1071195613740107139}
-  m_LocalRotation: {x: -0, y: -0.5875475, z: -0, w: 0.80918974}
-  m_LocalPosition: {x: -0.0238, y: 0.016555587, z: -0.0785}
-  m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
+  m_LocalRotation: {x: -0, y: -0.0000028014176, z: -0, w: 1}
+  m_LocalPosition: {x: -12.67, y: -1.78, z: -6.8}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 7
+  m_Father: {fileID: 1830317250909015653}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &5963241649819088105
 CapsuleCollider:
@@ -42,7 +42,7 @@ CapsuleCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 11
-  m_Height: 13.648407
+  m_Height: 33.7
   m_Direction: 1
   m_Center: {x: -0.2015881, y: 0, z: 0}
 --- !u!114 &4241830336152758511
@@ -101,6 +101,38 @@ MonoBehaviour:
     positionOffset: {x: 0, y: 0, z: 0}
   m_posOffsetData: {fileID: 0}
   listenerMask: 1
+--- !u!1 &1345817763297292280
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8658485523284553378}
+  m_Layer: 0
+  m_Name: Colliders
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8658485523284553378
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1345817763297292280}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1830317250909015653}
+  - {fileID: 8443339724056421785}
+  m_Father: {fileID: 2139315878358439016}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1441539742504560626
 GameObject:
   m_ObjectHideFlags: 0
@@ -112,7 +144,7 @@ GameObject:
   - component: {fileID: 1653371571100956835}
   - component: {fileID: 480702322421744423}
   m_Layer: 0
-  m_Name: colliders (2)
+  m_Name: Box (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -125,13 +157,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1441539742504560626}
-  m_LocalRotation: {x: -0, y: -0.8813306, z: -0, w: 0.47250018}
-  m_LocalPosition: {x: -0.0101, y: 0.016555587, z: -0.091}
-  m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
+  m_LocalRotation: {x: 0, y: 0.43680182, z: 0, w: 0.89955777}
+  m_LocalPosition: {x: -18.64, y: 0.87731475, z: 3.94}
+  m_LocalScale: {x: 0.93513405, y: 1, z: 1.0725169}
   m_Children: []
-  m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: -123.607, z: 0}
+  m_Father: {fileID: 1830317250909015653}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 51.8, z: 0}
 --- !u!65 &480702322421744423
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -143,8 +175,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 9.860867, y: 4.8280225, z: 11.570937}
-  m_Center: {x: -4.380995, y: -0.25970885, z: -0.64969593}
+  m_Size: {x: 1, y: 4.8280225, z: 11.570937}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1473638255942157095
 GameObject:
   m_ObjectHideFlags: 0
@@ -156,7 +188,7 @@ GameObject:
   - component: {fileID: 2212943635767871815}
   - component: {fileID: 7846269679662715128}
   m_Layer: 0
-  m_Name: colliders (5)
+  m_Name: Capsule
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -170,11 +202,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1473638255942157095}
   m_LocalRotation: {x: -0, y: -0.5875475, z: -0, w: 0.80918974}
-  m_LocalPosition: {x: 0.0335, y: 0.016555587, z: 0.0743}
-  m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
+  m_LocalPosition: {x: 0.033500005, y: -0.018000003, z: 0.074300006}
+  m_LocalScale: {x: 0.007388857, y: 0.012311829, z: 0.008260292}
   m_Children: []
-  m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 4
+  m_Father: {fileID: 8443339724056421785}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &7846269679662715128
 CapsuleCollider:
@@ -187,7 +219,7 @@ CapsuleCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 7.8
-  m_Height: 13.648407
+  m_Height: 26.3
   m_Direction: 1
   m_Center: {x: -0.2015881, y: 0, z: 0}
 --- !u!1 &1915263855968032856
@@ -201,7 +233,7 @@ GameObject:
   - component: {fileID: 3427834628318240954}
   - component: {fileID: 6957638227452557067}
   m_Layer: 0
-  m_Name: colliders (6)
+  m_Name: Capsule (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -215,11 +247,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1915263855968032856}
   m_LocalRotation: {x: -0, y: -0.5875475, z: -0, w: 0.80918974}
-  m_LocalPosition: {x: -0.0143, y: 0.016555587, z: 0.0879}
-  m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
+  m_LocalPosition: {x: -0.0143, y: -0.018, z: 0.08790001}
+  m_LocalScale: {x: 0.007388857, y: 0.012311829, z: 0.008260292}
   m_Children: []
-  m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 8
+  m_Father: {fileID: 8443339724056421785}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &6957638227452557067
 CapsuleCollider:
@@ -232,9 +264,44 @@ CapsuleCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 7.8
-  m_Height: 13.648407
+  m_Height: 26.3
   m_Direction: 1
   m_Center: {x: -0.2015881, y: 0, z: 0}
+--- !u!1 &1936673721802715957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8443339724056421785}
+  m_Layer: 0
+  m_Name: Left End
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8443339724056421785
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1936673721802715957}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2212943635767871815}
+  - {fileID: 4002916021404111106}
+  - {fileID: 3427834628318240954}
+  - {fileID: 5668059410098887477}
+  - {fileID: 8642056788288058711}
+  m_Father: {fileID: 8658485523284553378}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3164686574063363707
 GameObject:
   m_ObjectHideFlags: 0
@@ -262,18 +329,55 @@ Transform:
   m_LocalPosition: {x: -1.137001, y: -0.35800004, z: -1.4465599}
   m_LocalScale: {x: 119.56562, y: 81.22272, z: 137.2583}
   m_Children:
-  - {fileID: 2859927230155865726}
-  - {fileID: 1653371571100956835}
-  - {fileID: 7424860868265688611}
-  - {fileID: 5668059410098887477}
-  - {fileID: 2212943635767871815}
-  - {fileID: 4002916021404111106}
   - {fileID: 4136523412501458233}
-  - {fileID: 226697757065873532}
-  - {fileID: 3427834628318240954}
+  - {fileID: 8658485523284553378}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 71.966, z: 0}
+--- !u!1 &4013137427442207082
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8642056788288058711}
+  - component: {fileID: 4114735830218341375}
+  m_Layer: 0
+  m_Name: Box (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8642056788288058711
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4013137427442207082}
+  m_LocalRotation: {x: 0, y: -0.6198474, z: 0, w: 0.7847224}
+  m_LocalPosition: {x: 0.0971, y: 0.016555589, z: -0.0384}
+  m_LocalScale: {x: 0.007388857, y: 0.012311829, z: 0.008260292}
+  m_Children: []
+  m_Father: {fileID: 8443339724056421785}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: -76.61, z: 0}
+--- !u!65 &4114735830218341375
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4013137427442207082}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 11.6, y: 4.8280225, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &4281409562773872190
 GameObject:
   m_ObjectHideFlags: 0
@@ -285,7 +389,7 @@ GameObject:
   - component: {fileID: 7424860868265688611}
   - component: {fileID: 1212363963279600531}
   m_Layer: 0
-  m_Name: colliders (3)
+  m_Name: Box (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -298,13 +402,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4281409562773872190}
-  m_LocalRotation: {x: 0, y: 0.18480907, z: 0, w: 0.98277444}
-  m_LocalPosition: {x: -0.0775, y: 0.016555587, z: -0.033}
-  m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
+  m_LocalRotation: {x: 0, y: 0.7067364, z: 0, w: 0.707477}
+  m_LocalPosition: {x: -8.23, y: 0.87731475, z: 5.21}
+  m_LocalScale: {x: 0.8948461, y: 1, z: 1.1175561}
   m_Children: []
-  m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 21.3, z: 0}
+  m_Father: {fileID: 1830317250909015653}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 89.94, z: 0}
 --- !u!65 &1212363963279600531
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -316,7 +420,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 9.180189, y: 4.8280225, z: 11.570934}
+  m_Size: {x: 5, y: 4.8280225, z: 10.7}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5859798989810198206
 GameObject:
@@ -329,7 +433,7 @@ GameObject:
   - component: {fileID: 4002916021404111106}
   - component: {fileID: 112865078384561450}
   m_Layer: 0
-  m_Name: colliders (7)
+  m_Name: Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -342,12 +446,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5859798989810198206}
-  m_LocalRotation: {x: -0, y: -0.9996101, z: 0, w: -0.027921487}
-  m_LocalPosition: {x: 0.0681, y: 0.016555587, z: 0.0359}
-  m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
+  m_LocalRotation: {x: -0, y: -0.9996102, z: -0, w: -0.027921498}
+  m_LocalPosition: {x: 0.1059, y: 0.016555589, z: 0.0346}
+  m_LocalScale: {x: 0.0073888595, y: 0.012311829, z: 0.008260294}
   m_Children: []
-  m_Father: {fileID: 2139315878358439016}
-  m_RootOrder: 5
+  m_Father: {fileID: 8443339724056421785}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: -183.2, z: 0}
 --- !u!65 &112865078384561450
 BoxCollider:
@@ -360,7 +464,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 9.37, y: 4.8280225, z: 11.078685}
+  m_Size: {x: 1, y: 4.8280225, z: 11.078685}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &6719748475657299855
 GameObject:
@@ -373,7 +477,7 @@ GameObject:
   - component: {fileID: 5668059410098887477}
   - component: {fileID: 8028431355851493237}
   m_Layer: 0
-  m_Name: colliders (4)
+  m_Name: Box (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -386,13 +490,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6719748475657299855}
-  m_LocalRotation: {x: -0, y: -0.5875475, z: -0, w: 0.80918974}
-  m_LocalPosition: {x: 0.0109, y: 0.016555587, z: 0.0773}
-  m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
+  m_LocalRotation: {x: 0, y: 0.012216957, z: 0, w: 0.9999254}
+  m_LocalPosition: {x: -0.0805, y: 0.016555589, z: 0.0724}
+  m_LocalScale: {x: 0.007388857, y: 0.012311829, z: 0.008260292}
   m_Children: []
-  m_Father: {fileID: 2139315878358439016}
+  m_Father: {fileID: 8443339724056421785}
   m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 1.4, z: 0}
 --- !u!65 &8028431355851493237
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -404,8 +508,42 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 15.3, y: 4.8280225, z: 12.94}
+  m_Size: {x: 1, y: 4.8280225, z: 6.3}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &7446017454597549903
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1830317250909015653}
+  m_Layer: 0
+  m_Name: Right End
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1830317250909015653
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7446017454597549903}
+  m_LocalRotation: {x: -0, y: -0.5875452, z: -0, w: 0.8091914}
+  m_LocalPosition: {x: -0.039853074, y: 0.0057542413, z: 0.02552883}
+  m_LocalScale: {x: 0.0073888605, y: 0.012311829, z: 0.00826029}
+  m_Children:
+  - {fileID: 2859927230155865726}
+  - {fileID: 7424860868265688611}
+  - {fileID: 1653371571100956835}
+  - {fileID: 226697757065873532}
+  m_Father: {fileID: 8658485523284553378}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8720308148651886835
 GameObject:
   m_ObjectHideFlags: 0
@@ -417,7 +555,7 @@ GameObject:
   - component: {fileID: 2859927230155865726}
   - component: {fileID: 1379096916445825873}
   m_Layer: 0
-  m_Name: colliders (1)
+  m_Name: Box
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -430,11 +568,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8720308148651886835}
-  m_LocalRotation: {x: -0, y: -0.5875475, z: -0, w: 0.80918974}
-  m_LocalPosition: {x: 0.0109, y: 0.016555587, z: 0.0327}
-  m_LocalScale: {x: 0.007388855, y: 0.012311827, z: 0.008260289}
+  m_LocalRotation: {x: -0, y: -0.0000028014176, z: -0, w: 1}
+  m_LocalPosition: {x: -7.18, y: 0.87731475, z: -18.28}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 2139315878358439016}
+  m_Father: {fileID: 1830317250909015653}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &1379096916445825873
@@ -448,8 +586,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 12.719393, y: 4.8280225, z: 25.050749}
-  m_Center: {x: -11.244792, y: -0.25970885, z: -0.5549231}
+  m_Size: {x: 12.719393, y: 4.8280225, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &8943400015744058915
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -500,7 +638,7 @@ PrefabInstance:
     - target: {fileID: -4216859302048453862, guid: d3ef05419a1c2f44b8777c1f1b03f7b8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: d3ef05419a1c2f44b8777c1f1b03f7b8,
         type: 3}

--- a/2D3D_UnityProject/Assets/Prefabs/environment/Pier.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/environment/Pier.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 222090518674493298}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.03, y: 1.5, z: 0.62}
+  m_LocalPosition: {x: 0.03, y: 1.5, z: 0.895}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7585744551659616723}
@@ -42,7 +42,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.1, y: 1.5, z: 5.75}
+  m_Size: {x: 0.75, y: 1.5, z: 5.75}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &2276838843370858511
 GameObject:
@@ -68,13 +68,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2276838843370858511}
-  m_LocalRotation: {x: -0.2598355, y: -0.65763634, z: 0.2598355, w: 0.65763634}
-  m_LocalPosition: {x: -0.041000053, y: -0.30800003, z: 2.7370012}
+  m_LocalRotation: {x: -0.25983286, y: -0.65763736, z: 0.25983286, w: 0.65763736}
+  m_LocalPosition: {x: -0.04, y: -0.543, z: 2.395}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 3663686074322698111}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: -90.00001, z: 43.118004}
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 43.118004}
 --- !u!65 &4210126269428655835
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -86,7 +86,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.3, y: 1, z: 1}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &3486053332242644750
 GameObject:
@@ -147,7 +147,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3875419226355269396}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -2.75, y: 1.5, z: 0.15}
+  m_LocalPosition: {x: -2.956, y: 1.5, z: 0.15}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7585744551659616723}
@@ -164,7 +164,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.1, y: 1.5, z: 1.2}
+  m_Size: {x: 0.75, y: 1.5, z: 2}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &4865412974859354458
 GameObject:
@@ -223,7 +223,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6432366528293213528}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.03, y: 1.5, z: -0.33}
+  m_LocalPosition: {x: 0.03, y: 1.5, z: -0.627}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7585744551659616723}
@@ -240,7 +240,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.1, y: 1.5, z: 5.75}
+  m_Size: {x: 0.75, y: 1.5, z: 5.75}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &7338486927562378225
 GameObject:
@@ -311,7 +311,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7998076049443251164}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.136, z: 0.35}
+  m_LocalPosition: {x: 0, y: 1.383, z: 0.12}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 3663686074322698111}
@@ -328,7 +328,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 0.1, z: 5.75}
+  m_Size: {x: 1, y: 1, z: 6.5}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &8775444763853871175
 GameObject:

--- a/2D3D_UnityProject/Assets/Prefabs/environment/Pier.prefab
+++ b/2D3D_UnityProject/Assets/Prefabs/environment/Pier.prefab
@@ -1,5 +1,49 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &222090518674493298
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7331601492279503110}
+  - component: {fileID: 4640811623948153355}
+  m_Layer: 0
+  m_Name: Right Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7331601492279503110
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222090518674493298}
+  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.03, y: 1.5, z: 0.62}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7585744551659616723}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4640811623948153355
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222090518674493298}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.1, y: 1.5, z: 5.75}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &2276838843370858511
 GameObject:
   m_ObjectHideFlags: 0
@@ -11,7 +55,7 @@ GameObject:
   - component: {fileID: 226915235700371721}
   - component: {fileID: 4210126269428655835}
   m_Layer: 0
-  m_Name: diagonalCollider
+  m_Name: Steps
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -24,11 +68,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2276838843370858511}
-  m_LocalRotation: {x: -0.25983548, y: -0.6576363, z: 0.25983548, w: 0.6576363}
-  m_LocalPosition: {x: -0.041, y: -0.308, z: 2.737}
+  m_LocalRotation: {x: -0.2598355, y: -0.65763634, z: 0.2598355, w: 0.65763634}
+  m_LocalPosition: {x: -0.041000053, y: -0.30800003, z: 2.7370012}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 9037660324765928015}
+  m_Father: {fileID: 3663686074322698111}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: -90.00001, z: 43.118004}
 --- !u!65 &4210126269428655835
@@ -53,10 +97,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3663686074322698111}
-  - component: {fileID: 7152813919611760373}
-  - component: {fileID: 2630035855568922394}
-  - component: {fileID: 7580845663703077666}
-  - component: {fileID: 589356266291619662}
   m_Layer: 0
   m_Name: colliders
   m_TagString: Untagged
@@ -74,62 +114,58 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 6166382059062589930}
+  - {fileID: 226915235700371721}
+  - {fileID: 7585744551659616723}
+  - {fileID: 8892621087181804375}
   m_Father: {fileID: 9037660324765928015}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &7152813919611760373
+--- !u!1 &3875419226355269396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7369609483157964493}
+  - component: {fileID: 5716324661646535945}
+  m_Layer: 0
+  m_Name: Back Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7369609483157964493
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3875419226355269396}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -2.75, y: 1.5, z: 0.15}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7585744551659616723}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &5716324661646535945
 BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3486053332242644750}
+  m_GameObject: {fileID: 3875419226355269396}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 0.5987898, z: 4.9278884}
-  m_Center: {x: 1.0430067e-16, y: -0.1364117, z: -0.04576953}
---- !u!65 &2630035855568922394
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3486053332242644750}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 0.10931011}
-  m_Center: {x: 1.1682719e-14, y: 0, z: -2.4594235}
---- !u!65 &7580845663703077666
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3486053332242644750}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.08524217, y: 1.0481455, z: 0.82346827}
-  m_Center: {x: 0.45737904, y: -0.00000003973643, z: 2.7121906}
---- !u!65 &589356266291619662
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3486053332242644750}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.09326542, y: 1.0481455, z: 0.82346827}
-  m_Center: {x: -0.48546657, y: -0.00000003973643, z: 2.7121904}
+  m_Size: {x: 0.1, y: 1.5, z: 1.2}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &4865412974859354458
 GameObject:
   m_ObjectHideFlags: 0
@@ -161,6 +197,171 @@ Transform:
   - {fileID: 9037660324765928015}
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6432366528293213528
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4381039984002210749}
+  - component: {fileID: 2511299668043370984}
+  m_Layer: 0
+  m_Name: Left Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4381039984002210749
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6432366528293213528}
+  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.03, y: 1.5, z: -0.33}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7585744551659616723}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2511299668043370984
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6432366528293213528}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.1, y: 1.5, z: 5.75}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &7338486927562378225
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6166382059062589930}
+  - component: {fileID: 4638484158727495210}
+  m_Layer: 0
+  m_Name: Floor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6166382059062589930
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7338486927562378225}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3663686074322698111}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4638484158727495210
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7338486927562378225}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.5987898, z: 4.9278884}
+  m_Center: {x: 1.0430067e-16, y: -0.1364117, z: -0.04576953}
+--- !u!1 &7998076049443251164
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8892621087181804375}
+  - component: {fileID: 7423642895236566494}
+  m_Layer: 0
+  m_Name: Ceiling
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8892621087181804375
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7998076049443251164}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.136, z: 0.35}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3663686074322698111}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &7423642895236566494
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7998076049443251164}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.1, z: 5.75}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &8775444763853871175
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7585744551659616723}
+  m_Layer: 0
+  m_Name: Walls
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7585744551659616723
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8775444763853871175}
+  m_LocalRotation: {x: -0, y: -0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.13559785, y: -1.17, z: 0.2893563}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7331601492279503110}
+  - {fileID: 4381039984002210749}
+  - {fileID: 7369609483157964493}
+  m_Father: {fileID: 3663686074322698111}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &4041572609509892437
 PrefabInstance:


### PR DESCRIPTION
## Before (collider blocking pier outlined in red)
![image](https://user-images.githubusercontent.com/23004127/82254367-b8674400-9920-11ea-9f54-f985f6b0595d.png)


## After
![image](https://user-images.githubusercontent.com/23004127/82254283-91a90d80-9920-11ea-9e8d-0289f17c27de.png)


Adjusted collider blocking pier steps; player can now walk onto pier.
Generally organized collider hierarchy / prefab overrides as well.

No scene changes made, only relevant prefabs were modified

----

### Testing

1. Ensure you can walk up the pier steps and around the pier comfortably
2. Ensure you can't walk into the pond easily
    - I know it's possible because of my shitty movement code, but I want it to be unlikely to happen
